### PR TITLE
Improve hero contrast and readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,8 +81,43 @@
     /* Hero background tuned to brand/accent */
     .hero-bg{
       background:
-        radial-gradient(800px 400px at 10% -10%, rgba(20,199,232,.25), transparent),
-        radial-gradient(900px 500px at 110% 10%, rgba(11,31,68,.60), rgba(11,31,68,.95));
+        radial-gradient(800px 400px at 10% -10%, rgba(20,199,232,.18), transparent),
+        radial-gradient(900px 500px at 110% 10%, rgba(11,31,68,.70), rgba(11,31,68,.95));
+      position: relative;
+      isolation: isolate;
+    }
+    .hero-bg::before{
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(125deg, rgba(5,12,26,.88) 0%, rgba(5,14,30,.82) 45%, rgba(11,31,68,.55) 75%, rgba(20,199,232,.15) 100%);
+      z-index: 0;
+    }
+
+    .hero-bg > *{ position: relative; z-index: 1; }
+
+    .hero-copy{
+      background: linear-gradient(140deg, rgba(8,21,46,.86), rgba(8,28,54,.78));
+      border-radius: 1.75rem;
+      padding: 2rem;
+      border: 1px solid rgba(255,255,255,.12);
+      box-shadow: 0 30px 70px rgba(4,11,24,.45);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+    }
+    @media (min-width: 768px){
+      .hero-copy{ padding: 2.5rem; }
+    }
+    @media (min-width: 1024px){
+      .hero-copy{ padding: 3rem; max-width: 520px; }
+    }
+
+    .hero-copy h1{ color: #f6fbff; }
+    .hero-copy p{ color: rgba(255,255,255,.92); }
+    .hero-copy .chip{
+      background: rgba(255,255,255,.16);
+      border-color: rgba(255,255,255,.35);
+      color: #f4fbff;
     }
 
     /* Badges and subtle accents */
@@ -118,10 +153,10 @@
   <!-- Hero -->
   <section class="relative overflow-hidden hero-bg">
     <div class="mx-auto max-w-6xl px-4 py-12 lg:py-18 grid gap-10 lg:grid-cols-2 items-center">
-      <div class="text-white">
+      <div class="hero-copy text-white">
         <span class="chip inline-block rounded-full px-3 py-1 text-xs uppercase tracking-wider border-white/30">Beta waitlist open</span>
         <h1 class="mt-4 text-4xl/tight lg:text-6xl heading">Find the perfect cruise. <span style="color:var(--accent)">Easily.</span></h1>
-        <p class="mt-4 text-lg text-white/90">Cruisora is the app that lets you search deeper, compare price-per-night, and get personalized alerts when prices change or new sailings match your style.</p>
+        <p class="mt-4 text-lg leading-relaxed">Cruisora is the app that lets you search deeper, compare price-per-night, and get personalized alerts when prices change or new sailings match your style.</p>
 
         <!-- Anchor target -->
         <div id="waitlist" class="pt-1"></div>


### PR DESCRIPTION
## Summary
- add a darker gradient overlay to the hero background and isolate content layers for clarity
- wrap hero copy in a glassmorphism panel with refined typography colors for higher contrast

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e31abd7f68832db67887d7be428e2c