### PR TITLE
Fix Mailchimp newsletter signup field styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,13 +86,35 @@
       border-radius:.75rem;
     }
     #mc_embed_signup .mc-field-group{ margin:0 }
+    #mc_embed_signup .mc-field-group label{ display:block; font-size:.8rem; font-weight:600; color:rgba(255,255,255,.72); margin-bottom:.4rem; }
+    #mc_embed_signup .mc-field-group label .asterisk{ color:rgba(20,199,232,.85); }
+    #mc_embed_signup .mc-field-group input[type="email"]{
+      display:block;
+      width:100%;
+      border-radius:0.85rem;
+      border:1px solid rgba(11,31,68,.18);
+      background-color:#ffffff;
+      color:#0b1f44;
+      padding:0.65rem 1rem;
+      font-size:1rem;
+      line-height:1.4;
+      transition:box-shadow .2s ease, border-color .2s ease;
+    }
+    #mc_embed_signup .mc-field-group input[type="email"]::placeholder{ color:rgba(11,31,68,.45); }
+    #mc_embed_signup .mc-field-group input[type="email"]:focus{
+      outline:none;
+      border-color:rgba(20,199,232,.65);
+      box-shadow:0 0 0 4px rgba(20,199,232,.25);
+    }
     #mc_embed_signup .optionalParent{ margin-top:.35rem }
     @media (min-width: 640px){
       #mc_embed_signup .optionalParent{ margin-top:0 }
     }
     #mc_embed_signup .refferal_badge{ display:none!important }
-    #mc_embed_signup input[type="email"]{
-      background-color:#ffffff;
+    #mc_embed_signup .foot{ margin-top:.65rem; }
+    #mc_embed_signup .foot .button,
+    #mc_embed_signup button[type="submit"]{
+      cursor:pointer;
     }
 
     /* Crisp images */
@@ -353,18 +375,13 @@
           <!-- IMPORTANT: Replace COM with your Mailchimp subdomain (e.g., xyz.us6) -->
           <form action="https://COM.us6.list-manage.com/subscribe/post?u=24aa21bb7924a415d000f32f8&amp;id=f0c508410d&amp;f_id=00b855e5f0"
                 method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form"
-                class="validate" novalidate>
-            <div id="mc_embed_signup_scroll" class="flex flex-col gap-1.5 sm:flex-row sm:items-end sm:gap-3">
+                class="validate" target="_blank" novalidate>
+            <div id="mc_embed_signup_scroll" class="flex flex-col gap-3 sm:flex-row sm:items-end sm:gap-4">
               <h2 class="sr-only">Join the Cruisora Deals Newsletter</h2>
               <div class="mc-field-group flex-1 w-full">
-                <label for="mce-EMAIL" class="sr-only">Email Address</label>
-                <input type="email" name="EMAIL" id="mce-EMAIL" required
-                       class="required email w-full rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-slate-900 placeholder-slate-500 focus:outline-none focus:ring-4 focus:ring-cyan-300"
+                <label for="mce-EMAIL">Email Address <span class="asterisk" aria-hidden="true">*</span></label>
+                <input type="email" name="EMAIL" class="required email" id="mce-EMAIL" required
                        placeholder="you@email.com">
-              </div>
-              <div id="mce-responses" class="clear foot text-sm">
-                <div class="response" id="mce-error-response" style="display:none;color:#B00020;"></div>
-                <div class="response" id="mce-success-response" style="display:none;color:#0A7F3F;"></div>
               </div>
               <!-- honeypot -->
               <div aria-hidden="true" style="position:absolute; left:-5000px;">
@@ -378,6 +395,10 @@
                   </button>
                 </div>
               </div>
+            </div>
+            <div id="mce-responses" class="clear foot text-sm text-left">
+              <div class="response" id="mce-error-response" style="display:none;color:#B00020;"></div>
+              <div class="response" id="mce-success-response" style="display:none;color:#0A7F3F;"></div>
             </div>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- update the hero newsletter form markup to match the Mailchimp embed requirements, including target and labels
- restyle the email input to present a white field with accessible focus states while keeping error and success messaging visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e32f93d910832db7444402a5ffd1a0