### PR TITLE
Add Cruisora contact info and footer navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -581,7 +581,7 @@
     <div class="mx-auto max-w-6xl px-4 py-10 text-sm text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <div class="space-y-2 sm:space-y-1">
         <p>© <span id="y"></span> cruisora • <a class="hover:underline" href="#">Privacy</a> • <a class="hover:underline" href="#">Terms</a></p>
-        <p class="text-slate-500">Cruisora • <a class="hover:underline" href="tel:13056976080">305.697.6080</a> • <a class="hover:underline" href="mailto:hellow@cruisora.com">hellow@cruisora.com</a></p>
+        <p class="text-slate-500">Cruisora • <a class="hover:underline" href="tel:13056976080">305.697.6080</a> • <a class="hover:underline" href="mailto:hello@cruisora.com">hello@cruisora.com</a></p>
         <nav class="flex flex-wrap gap-x-4 gap-y-2 text-slate-500">
           <a class="hover:underline" href="#">Careers</a>
           <a class="hover:underline" href="#">Team</a>

--- a/index.html
+++ b/index.html
@@ -578,8 +578,18 @@
 
   <!-- Footer -->
   <footer class="border-t border-slate-200 bg-white">
-    <div class="mx-auto max-w-6xl px-4 py-10 text-sm text-slate-600 flex items-center justify-between">
-      <p>© <span id="y"></span> cruisora • <a class="hover:underline" href="#">Privacy</a> • <a class="hover:underline" href="#">Terms</a></p>
+    <div class="mx-auto max-w-6xl px-4 py-10 text-sm text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="space-y-2 sm:space-y-1">
+        <p>© <span id="y"></span> cruisora • <a class="hover:underline" href="#">Privacy</a> • <a class="hover:underline" href="#">Terms</a></p>
+        <p class="text-slate-500">Cruisora • <a class="hover:underline" href="tel:13056976080">305.697.6080</a> • <a class="hover:underline" href="mailto:hellow@cruisora.com">hellow@cruisora.com</a></p>
+        <nav class="flex flex-wrap gap-x-4 gap-y-2 text-slate-500">
+          <a class="hover:underline" href="#">Careers</a>
+          <a class="hover:underline" href="#">Team</a>
+          <a class="hover:underline" href="#">Contact Us</a>
+          <a class="hover:underline" href="#">FAQs</a>
+          <a class="hover:underline" href="#">Affiliate Disclosure</a>
+        </nav>
+      </div>
       <div class="flex gap-4">
         <a class="hover:underline" href="https://www.instagram.com/cruisora" aria-label="Instagram">Instagram</a>
         <a class="hover:underline" href="https://www.tiktok.com/@cruisora" aria-label="TikTok">TikTok</a>


### PR DESCRIPTION
## Summary
- update the footer layout to stack on small screens
- add Cruisora phone number and email address as clickable links
- add Careers, Team, Contact Us, FAQs, and Affiliate Disclosure footer links

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e32d5fb6c4832d8b7b5f777eb701d7