### PR TITLE
Add hero carousel with mockup and photo

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,24 +171,31 @@
     }
     .hero-collage-photo{
       position: absolute;
-      top: -12%;
-      right: -14%;
-      width: 68%;
-      transform: rotate(7deg);
-      z-index: 1;
+      top: -4%;
+      right: -22%;
+      width: 78%;
+      transform: rotate(5deg);
+      z-index: 4;
     }
     @media (max-width: 640px){
       .hero-collage-photo{
-        top: -6%;
-        right: -4%;
-        width: 74%;
+        top: 4%;
+        right: -10%;
+        width: 82%;
+      }
+    }
+    @media (min-width: 1024px){
+      .hero-collage-photo{
+        top: -2%;
+        right: -28%;
+        width: 84%;
       }
     }
     .hero-collage-alert{
       position: absolute;
-      left: 12%;
-      bottom: -4.5rem;
-      z-index: 3;
+      left: -4%;
+      bottom: -4.25rem;
+      z-index: 6;
       display: flex;
       flex-direction: column;
       gap: .4rem;
@@ -220,7 +227,7 @@
     }
     @media (min-width: 768px){
       .hero-collage-alert{
-        bottom: -5.25rem;
+        bottom: -5rem;
         padding: 1.35rem 2rem;
       }
       .hero-collage-alert-body{
@@ -229,14 +236,14 @@
     }
     @media (min-width: 1024px){
       .hero-collage-alert{
-        left: 18%;
+        left: 2%;
       }
     }
     @media (max-width: 480px){
       .hero-collage-alert{
-        left: 6%;
-        bottom: -3.25rem;
-        width: min(88%, 320px);
+        left: 2%;
+        bottom: -3rem;
+        width: min(90%, 320px);
         padding: .95rem 1.4rem;
       }
       .hero-collage-alert-body{

--- a/index.html
+++ b/index.html
@@ -171,41 +171,41 @@
     }
     .hero-collage-photo{
       position: absolute;
-      top: -4%;
-      right: -22%;
-      width: 78%;
-      transform: rotate(5deg);
+      top: -6%;
+      right: -18%;
+      width: 70%;
+      transform: rotate(4deg);
       z-index: 4;
     }
     @media (max-width: 640px){
       .hero-collage-photo{
-        top: 4%;
-        right: -10%;
-        width: 82%;
+        top: 6%;
+        right: -6%;
+        width: 78%;
       }
     }
     @media (min-width: 1024px){
       .hero-collage-photo{
-        top: -2%;
-        right: -28%;
-        width: 84%;
+        top: -4%;
+        right: -22%;
+        width: 74%;
       }
     }
     .hero-collage-alert{
       position: absolute;
-      left: -4%;
-      bottom: -4.25rem;
+      right: -6%;
+      bottom: -14%;
       z-index: 6;
       display: flex;
       flex-direction: column;
       gap: .4rem;
-      padding: 1.2rem 1.65rem;
+      padding: 1.15rem 1.5rem;
       border-radius: 1.5rem;
       background: rgba(255,255,255,.96);
       color: var(--brand-ink);
       border: 1px solid rgba(11,31,68,.12);
-      box-shadow: 0 30px 65px rgba(5,16,32,.3);
-      width: clamp(240px, 70%, 360px);
+      box-shadow: 0 30px 60px rgba(5,16,32,.28);
+      width: clamp(220px, 68%, 320px);
     }
     .hero-collage-alert-label{
       text-transform: uppercase;
@@ -227,8 +227,9 @@
     }
     @media (min-width: 768px){
       .hero-collage-alert{
-        bottom: -5rem;
-        padding: 1.35rem 2rem;
+        right: -4%;
+        bottom: -16%;
+        padding: 1.3rem 1.85rem;
       }
       .hero-collage-alert-body{
         font-size: 1rem;
@@ -236,15 +237,17 @@
     }
     @media (min-width: 1024px){
       .hero-collage-alert{
-        left: 2%;
+        right: -2%;
+        bottom: -18%;
       }
     }
     @media (max-width: 480px){
       .hero-collage-alert{
-        left: 2%;
-        bottom: -3rem;
-        width: min(90%, 320px);
-        padding: .95rem 1.4rem;
+        right: auto;
+        left: 6%;
+        bottom: -12%;
+        width: min(88%, 300px);
+        padding: 1rem 1.35rem;
       }
       .hero-collage-alert-body{
         font-size: .88rem;
@@ -466,7 +469,7 @@
   
 <body>
   <!-- Header -->
-  <header class="border-b border-slate-200 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/60 sticky top-0 z-40">
+  <header class="border-b border-slate-200 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/60 fixed inset-x-0 top-0 z-50">
     <div class="mx-auto max-w-6xl px-4 py-4 flex items-center justify-between">
       <a href="#" class="flex items-center gap-3">
         <!-- New logo image -->
@@ -482,7 +485,7 @@
   </header>
 
   <!-- Hero -->
-  <section class="relative overflow-hidden hero-bg">
+  <section class="relative overflow-hidden hero-bg pt-28 sm:pt-32">
     <div class="mx-auto max-w-6xl px-4 py-12 lg:py-18 grid gap-10 lg:grid-cols-2 items-center">
       <div class="hero-copy text-white">
         <span class="chip inline-block rounded-full px-3 py-1 text-xs uppercase tracking-wider border-white/30">Cruise deal newsletter now open</span>
@@ -542,6 +545,13 @@
               <img src="https://images.unsplash.com/photo-1533105079780-92b9be482077?auto=format&fit=crop&w=1600&q=80"
                    alt="Cruise ship gliding through the Greek Isles" referrerpolicy="no-referrer">
             </div>
+            <div class="hero-collage-alert">
+              <span class="hero-collage-alert-label">Sample alert</span>
+              <div class="hero-collage-alert-body">
+                <span>🔔</span>
+                <span>Price dropped 18% on your saved Europe sailing.</span>
+              </div>
+            </div>
           </div>
           <div class="newsletter-inbox">
             <div class="inbox-status">
@@ -587,13 +597,6 @@
               <button type="button" class="email-cta">View all deals</button>
             </div>
             <p class="email-footer-note">Sent from your Cruisora watchlist alerts</p>
-          </div>
-          <div class="hero-collage-alert">
-            <span class="hero-collage-alert-label">Sample alert</span>
-            <div class="hero-collage-alert-body">
-              <span>🔔</span>
-              <span>Price dropped 18% on your saved Europe sailing.</span>
-            </div>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -154,19 +154,32 @@
     .hero-carousel{
       width: min(100%, 540px);
       position: relative;
+      overflow: hidden;
+      min-height: 420px;
+    }
+    @media (min-width: 768px){
+      .hero-carousel{ min-height: 520px; }
     }
     .hero-carousel-track{
-      display: flex;
-      transition: transform .6s ease;
-      will-change: transform;
-      overflow: visible;
+      position: relative;
+      height: 100%;
       touch-action: pan-y;
     }
     .hero-slide{
-      flex: 0 0 100%;
+      position: absolute;
+      inset: 0;
       display: flex;
       justify-content: center;
       padding-bottom: 3rem;
+      transition: transform .6s ease, opacity .6s ease;
+      will-change: transform, opacity;
+      opacity: 0;
+      pointer-events: none;
+    }
+    .hero-slide:first-child{
+      position: relative;
+      opacity: 1;
+      pointer-events: auto;
     }
     .hero-carousel-nav{
       display: flex;
@@ -234,7 +247,7 @@
     }
     @media (min-width: 768px){
       .hero-media .newsletter-inbox{
-        transform: rotateX(8deg) rotateY(-12deg);
+        transform: rotateX(8deg) rotateY(12deg);
       }
     }
     @media (min-width: 1024px){
@@ -242,7 +255,7 @@
         perspective: 2000px;
       }
       .hero-media .newsletter-inbox{
-        transform: rotateX(10deg) rotateY(-16deg);
+        transform: rotateX(10deg) rotateY(16deg);
       }
     }
     .hero-photo-card{
@@ -776,9 +789,29 @@
       const prefersReduced=window.matchMedia('(prefers-reduced-motion: reduce)').matches;
       const autoplayEnabled=carousel.hasAttribute('data-autoplay')&&!prefersReduced;
 
+      const updateHeight=()=>{
+        const active=slides[index];
+        if(!active) return;
+        carousel.style.height=`${active.offsetHeight}px`;
+      };
+
+      const setPositions=()=>{
+        slides.forEach((slide,i)=>{
+          const offset=i-index;
+          slide.style.position='absolute';
+          slide.dataset.state=offset===0?'active':'inactive';
+          slide.style.opacity=offset===0?'1':'0';
+          slide.style.pointerEvents=offset===0?'auto':'none';
+          slide.style.transform=`translateY(${offset*110}%)`;
+          slide.style.zIndex=String(slides.length-Math.abs(offset));
+        });
+        updateHeight();
+        requestAnimationFrame(updateHeight);
+      };
+
       const setSlide=(nextIndex)=>{
         index=(nextIndex+slides.length)%slides.length;
-        track.style.transform=`translateX(-${index*100}%)`;
+        setPositions();
         dots.forEach((dot,i)=>{
           dot.setAttribute('aria-current', i===index ? 'true' : 'false');
         });
@@ -797,21 +830,21 @@
       next?.addEventListener('click',()=>{goNext(); restartAutoplay();});
       dots.forEach((dot,i)=>dot.addEventListener('click',()=>{setSlide(i); restartAutoplay();}));
 
-      // Swipe gestures
+      // Swipe gestures (vertical)
       let pointerActive=false;
-      let startX=0;
-      let deltaX=0;
+      let startY=0;
+      let deltaY=0;
       track.addEventListener('pointerdown',(event)=>{
         pointerActive=true;
-        startX=event.clientX;
-        deltaX=0;
+        startY=event.clientY;
+        deltaY=0;
         if(track.setPointerCapture){
           track.setPointerCapture(event.pointerId);
         }
       });
       track.addEventListener('pointermove',(event)=>{
         if(!pointerActive) return;
-        deltaX=event.clientX-startX;
+        deltaY=event.clientY-startY;
       });
       const endPointer=(event)=>{
         if(!pointerActive) return;
@@ -819,14 +852,18 @@
         if(track.hasPointerCapture&&track.hasPointerCapture(event.pointerId)){
           track.releasePointerCapture(event.pointerId);
         }
-        if(Math.abs(deltaX)>40){
-          deltaX>0?goPrev():goNext();
+        if(Math.abs(deltaY)>40){
+          deltaY>0?goPrev():goNext();
           restartAutoplay();
         }
-        deltaX=0;
+        deltaY=0;
       };
       track.addEventListener('pointerup',endPointer);
       track.addEventListener('pointercancel',endPointer);
+
+      window.addEventListener('resize',()=>{
+        requestAnimationFrame(updateHeight);
+      });
 
       document.addEventListener('visibilitychange',()=>{
         if(!autoplayEnabled) return;
@@ -838,6 +875,7 @@
       });
 
       setSlide(0);
+      window.addEventListener('load',()=>requestAnimationFrame(updateHeight));
       restartAutoplay();
     })();
   </script>

--- a/index.html
+++ b/index.html
@@ -147,87 +147,101 @@
     .hero-media{
       position: relative;
       display: flex;
+      align-items: center;
       justify-content: center;
       padding: 2rem 0 6rem;
       perspective: 1400px;
     }
-    .hero-carousel{
-      width: min(100%, 540px);
+    .hero-collage{
       position: relative;
-      overflow: hidden;
-      min-height: 420px;
+      width: min(100%, 560px);
+      padding-top: 1.5rem;
+      padding-bottom: 4.5rem;
+      margin: 0 auto;
+    }
+    .hero-collage::before{
+      content: "";
+      position: absolute;
+      inset: 12% 8% 0 18%;
+      background: radial-gradient(circle at 50% 20%, rgba(20,199,232,.16), transparent 65%);
+      filter: blur(18px);
+      opacity: .9;
+      z-index: 0;
+      transform: rotate(4deg);
+    }
+    .hero-collage-photo{
+      position: absolute;
+      top: -12%;
+      right: -14%;
+      width: 68%;
+      transform: rotate(7deg);
+      z-index: 1;
+    }
+    @media (max-width: 640px){
+      .hero-collage-photo{
+        top: -6%;
+        right: -4%;
+        width: 74%;
+      }
+    }
+    .hero-collage-alert{
+      position: absolute;
+      left: 12%;
+      bottom: -4.5rem;
+      z-index: 3;
+      display: flex;
+      flex-direction: column;
+      gap: .4rem;
+      padding: 1.2rem 1.65rem;
+      border-radius: 1.5rem;
+      background: rgba(255,255,255,.96);
+      color: var(--brand-ink);
+      border: 1px solid rgba(11,31,68,.12);
+      box-shadow: 0 30px 65px rgba(5,16,32,.3);
+      width: clamp(240px, 70%, 360px);
+    }
+    .hero-collage-alert-label{
+      text-transform: uppercase;
+      letter-spacing: .32em;
+      font-size: .72rem;
+      font-weight: 700;
+      color: #b00020;
+    }
+    .hero-collage-alert-body{
+      font-size: .95rem;
+      line-height: 1.45;
+      display: flex;
+      align-items: center;
+      gap: .55rem;
+      font-weight: 500;
+    }
+    .hero-collage-alert-body span:first-child{
+      font-size: 1.1rem;
     }
     @media (min-width: 768px){
-      .hero-carousel{ min-height: 520px; }
+      .hero-collage-alert{
+        bottom: -5.25rem;
+        padding: 1.35rem 2rem;
+      }
+      .hero-collage-alert-body{
+        font-size: 1rem;
+      }
     }
-    .hero-carousel-track{
-      position: relative;
-      height: 100%;
-      touch-action: pan-y;
+    @media (min-width: 1024px){
+      .hero-collage-alert{
+        left: 18%;
+      }
     }
-    .hero-slide{
-      position: absolute;
-      inset: 0;
-      display: flex;
-      justify-content: center;
-      padding-bottom: 3rem;
-      transition: transform .6s ease, opacity .6s ease;
-      will-change: transform, opacity;
-      opacity: 0;
-      pointer-events: none;
-    }
-    .hero-slide:first-child{
-      position: relative;
-      opacity: 1;
-      pointer-events: auto;
-    }
-    .hero-carousel-nav{
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 1.5rem;
-      margin-top: 1.25rem;
-    }
-    .hero-carousel-button{
-      width: 2.5rem;
-      height: 2.5rem;
-      border-radius: 9999px;
-      border: 1px solid rgba(255,255,255,.28);
-      background: rgba(255,255,255,.14);
-      color: #f6fbff;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      backdrop-filter: blur(10px);
-      -webkit-backdrop-filter: blur(10px);
-      font-size: 1.15rem;
-      transition: background .3s ease, border-color .3s ease;
-    }
-    .hero-carousel-button:hover{
-      background: rgba(255,255,255,.24);
-      border-color: rgba(255,255,255,.45);
-    }
-    .hero-carousel-button:focus{
-      outline: 2px solid var(--accent-soft);
-      outline-offset: 2px;
-    }
-    .hero-carousel-dots{
-      display: flex;
-      align-items: center;
-      gap: .65rem;
-    }
-    .hero-carousel-dot{
-      width: .75rem;
-      height: .75rem;
-      border-radius: 9999px;
-      border: 0;
-      background: rgba(255,255,255,.28);
-      cursor: pointer;
-      transition: background .3s ease, width .3s ease;
-    }
-    .hero-carousel-dot[aria-current="true"]{
-      background: var(--accent);
-      width: 1.45rem;
+    @media (max-width: 480px){
+      .hero-collage-alert{
+        left: 6%;
+        bottom: -3.25rem;
+        width: min(88%, 320px);
+        padding: .95rem 1.4rem;
+      }
+      .hero-collage-alert-body{
+        font-size: .88rem;
+      }
     }
     .newsletter-inbox{
       width: min(100%, 520px);
@@ -241,6 +255,7 @@
       flex-direction: column;
       gap: 1.5rem;
       position: relative;
+      z-index: 2;
       -webkit-box-reflect: below 1.5rem linear-gradient(transparent 45%, rgba(5,16,32,.35));
       transform-origin: center bottom;
       transition: transform .6s ease;
@@ -260,7 +275,7 @@
     }
     @media (min-width: 768px){
       .hero-media .newsletter-inbox{
-        transform: rotateX(8deg) rotateY(12deg);
+        transform: rotateX(8deg) rotateY(-12deg);
       }
     }
     @media (min-width: 1024px){
@@ -268,7 +283,7 @@
         perspective: 2000px;
       }
       .hero-media .newsletter-inbox{
-        transform: rotateX(10deg) rotateY(16deg);
+        transform: rotateX(10deg) rotateY(-18deg);
       }
     }
     .hero-photo-card{
@@ -279,41 +294,17 @@
       box-shadow: 0 40px 90px rgba(4,14,30,.35);
       border: 1px solid rgba(255,255,255,.25);
     }
+    .hero-collage-photo .hero-photo-card{
+      box-shadow: 0 35px 90px rgba(4,14,30,.32);
+      border: 1px solid rgba(255,255,255,.35);
+    }
     .hero-photo-card img{
       width: 100%;
       height: 100%;
       max-height: 520px;
       object-fit: cover;
       display: block;
-    }
-    .hero-photo-alert{
-      position: absolute;
-      left: 50%;
-      bottom: 1.75rem;
-      transform: translateX(-50%);
-      background: rgba(255,255,255,.92);
-      color: #0b1f44;
-      border-radius: 1rem;
-      border: 1px solid rgba(11,31,68,.15);
-      box-shadow: 0 25px 55px rgba(5,16,32,.28);
-      padding: .85rem 1.25rem;
-      width: calc(100% - 2rem);
-      max-width: 420px;
-      font-size: .95rem;
-      line-height: 1.4;
-      display: flex;
-      align-items: center;
-      gap: .5rem;
-    }
-    @media (min-width: 1024px){
-      .hero-photo-alert{
-        font-size: 1rem;
-        padding: 1rem 1.75rem;
-        max-width: 480px;
-      }
-    }
-    .hero-photo-alert-label{
-      font-weight: 600;
+      filter: saturate(1.05);
     }
     .inbox-status{
       display: flex;
@@ -538,77 +529,64 @@
       </div>
 
       <div class="hero-media">
-        <div class="hero-carousel" data-hero-carousel data-autoplay="true">
-          <div class="hero-carousel-track" data-hero-track>
-            <div class="hero-slide" data-hero-slide>
-              <div class="newsletter-inbox">
-                <div class="inbox-status">
-                  <span>Inbox · Today</span>
-                  <span>3 new</span>
-                </div>
-                <div class="newsletter-email">
-                  <div class="email-meta">
-                    <div class="email-avatar">C</div>
-                    <div>
-                      <p class="email-from">Cruisora</p>
-                      <p class="email-to">to alicia@email.com</p>
-                    </div>
-                    <span class="email-time">9:12 AM</span>
-                  </div>
-                  <div>
-                    <div class="email-subject">Your weekly cruise picks just docked 🚢</div>
-                    <p class="email-intro">Hi Alicia, we scanned hundreds of sailings and pulled the matches that fit your saved ships and budget.</p>
-                  </div>
-                  <ul class="newsletter-deal-list">
-                    <li class="newsletter-deal">
-                      <div>
-                        <div class="deal-route">Barcelona ➜ Greek Isles</div>
-                        <div class="deal-details">7 nights · Celebrity Ascent · July 2025</div>
-                      </div>
-                      <span class="deal-tag">Save 22%</span>
-                    </li>
-                    <li class="newsletter-deal">
-                      <div>
-                        <div class="deal-route">Miami Escape &amp; CocoCay</div>
-                        <div class="deal-details">4 nights · Icon of the Seas · Spring 2025</div>
-                      </div>
-                      <span class="deal-tag">From $389</span>
-                    </li>
-                    <li class="newsletter-deal">
-                      <div>
-                        <div class="deal-route">Alaska Glacier Vista</div>
-                        <div class="deal-details">10 nights · Princess Discovery · August 2025</div>
-                      </div>
-                      <span class="deal-tag">New cabins</span>
-                    </li>
-                  </ul>
-                  <button type="button" class="email-cta">View all deals</button>
-                </div>
-                <p class="email-footer-note">Sent from your Cruisora watchlist alerts</p>
-              </div>
-            </div>
-            <div class="hero-slide" data-hero-slide>
-              <div class="hero-photo-card">
-                <img src="https://images.unsplash.com/photo-1533105079780-92b9be482077?auto=format&fit=crop&w=1600&q=80"
-                     alt="Cruise ship gliding through the Greek Isles" referrerpolicy="no-referrer">
-                <div class="hero-photo-alert">
-                  <span class="hero-photo-alert-label">🔔 Smart alert:</span>
-                  <span>Price dropped 18% on your saved Europe sailing.</span>
-                </div>
-              </div>
+        <div class="hero-collage">
+          <div class="hero-collage-photo">
+            <div class="hero-photo-card">
+              <img src="https://images.unsplash.com/photo-1533105079780-92b9be482077?auto=format&fit=crop&w=1600&q=80"
+                   alt="Cruise ship gliding through the Greek Isles" referrerpolicy="no-referrer">
             </div>
           </div>
-          <div class="hero-carousel-nav">
-            <button type="button" class="hero-carousel-button" data-hero-prev aria-label="Previous hero slide">
-              <span aria-hidden="true">‹</span>
-            </button>
-            <div class="hero-carousel-dots" role="tablist" aria-label="Hero slides">
-              <button type="button" class="hero-carousel-dot" aria-label="Show hero slide 1" aria-current="true" data-hero-dot="0"></button>
-              <button type="button" class="hero-carousel-dot" aria-label="Show hero slide 2" data-hero-dot="1"></button>
+          <div class="newsletter-inbox">
+            <div class="inbox-status">
+              <span>Inbox · Today</span>
+              <span>3 new</span>
             </div>
-            <button type="button" class="hero-carousel-button" data-hero-next aria-label="Next hero slide">
-              <span aria-hidden="true">›</span>
-            </button>
+            <div class="newsletter-email">
+              <div class="email-meta">
+                <div class="email-avatar">C</div>
+                <div>
+                  <p class="email-from">Cruisora</p>
+                  <p class="email-to">to alicia@email.com</p>
+                </div>
+                <span class="email-time">9:12 AM</span>
+              </div>
+              <div>
+                <div class="email-subject">Your weekly cruise picks just docked 🚢</div>
+                <p class="email-intro">Hi Alicia, we scanned hundreds of sailings and pulled the matches that fit your saved ships and budget.</p>
+              </div>
+              <ul class="newsletter-deal-list">
+                <li class="newsletter-deal">
+                  <div>
+                    <div class="deal-route">Barcelona ➜ Greek Isles</div>
+                    <div class="deal-details">7 nights · Celebrity Ascent · July 2025</div>
+                  </div>
+                  <span class="deal-tag">Save 22%</span>
+                </li>
+                <li class="newsletter-deal">
+                  <div>
+                    <div class="deal-route">Miami Escape &amp; CocoCay</div>
+                    <div class="deal-details">4 nights · Icon of the Seas · Spring 2025</div>
+                  </div>
+                  <span class="deal-tag">From $389</span>
+                </li>
+                <li class="newsletter-deal">
+                  <div>
+                    <div class="deal-route">Alaska Glacier Vista</div>
+                    <div class="deal-details">10 nights · Princess Discovery · August 2025</div>
+                  </div>
+                  <span class="deal-tag">New cabins</span>
+                </li>
+              </ul>
+              <button type="button" class="email-cta">View all deals</button>
+            </div>
+            <p class="email-footer-note">Sent from your Cruisora watchlist alerts</p>
+          </div>
+          <div class="hero-collage-alert">
+            <span class="hero-collage-alert-label">Sample alert</span>
+            <div class="hero-collage-alert-body">
+              <span>🔔</span>
+              <span>Price dropped 18% on your saved Europe sailing.</span>
+            </div>
           </div>
         </div>
       </div>
@@ -795,110 +773,6 @@
         .observe(successEl,{childList:true,subtree:true,attributes:true,characterData:true});
     })();
 
-    // Hero carousel logic
-    (function(){
-      const carousel=document.querySelector('[data-hero-carousel]');
-      if(!carousel) return;
-      const track=carousel.querySelector('[data-hero-track]');
-      const slides=[...carousel.querySelectorAll('[data-hero-slide]')];
-      const dots=[...carousel.querySelectorAll('[data-hero-dot]')];
-      const prev=carousel.querySelector('[data-hero-prev]');
-      const next=carousel.querySelector('[data-hero-next]');
-      if(!track||slides.length<=1) return;
-      let index=0;
-      let autoplayTimer;
-      const prefersReduced=window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-      const autoplayEnabled=carousel.hasAttribute('data-autoplay')&&!prefersReduced;
-
-      const updateHeight=()=>{
-        const active=slides[index];
-        if(!active) return;
-        carousel.style.height=`${active.offsetHeight}px`;
-      };
-
-      const setPositions=()=>{
-        slides.forEach((slide,i)=>{
-          const offset=i-index;
-          slide.style.position='absolute';
-          slide.dataset.state=offset===0?'active':'inactive';
-          slide.style.opacity=offset===0?'1':'0';
-          slide.style.pointerEvents=offset===0?'auto':'none';
-          slide.style.transform=`translateX(${offset*110}%)`;
-          slide.style.zIndex=String(slides.length-Math.abs(offset));
-        });
-        updateHeight();
-        requestAnimationFrame(updateHeight);
-      };
-
-      const setSlide=(nextIndex)=>{
-        index=(nextIndex+slides.length)%slides.length;
-        setPositions();
-        dots.forEach((dot,i)=>{
-          dot.setAttribute('aria-current', i===index ? 'true' : 'false');
-        });
-      };
-
-      const goNext=()=>setSlide(index+1);
-      const goPrev=()=>setSlide(index-1);
-
-      const restartAutoplay=()=>{
-        if(!autoplayEnabled) return;
-        clearInterval(autoplayTimer);
-        autoplayTimer=setInterval(goNext,6000);
-      };
-
-      prev?.addEventListener('click',()=>{goPrev(); restartAutoplay();});
-      next?.addEventListener('click',()=>{goNext(); restartAutoplay();});
-      dots.forEach((dot,i)=>dot.addEventListener('click',()=>{setSlide(i); restartAutoplay();}));
-
-      // Swipe gestures (horizontal)
-      let pointerActive=false;
-      let startX=0;
-      let deltaX=0;
-      track.addEventListener('pointerdown',(event)=>{
-        pointerActive=true;
-        startX=event.clientX;
-        deltaX=0;
-        if(track.setPointerCapture){
-          track.setPointerCapture(event.pointerId);
-        }
-      });
-      track.addEventListener('pointermove',(event)=>{
-        if(!pointerActive) return;
-        deltaX=event.clientX-startX;
-      });
-      const endPointer=(event)=>{
-        if(!pointerActive) return;
-        pointerActive=false;
-        if(track.hasPointerCapture&&track.hasPointerCapture(event.pointerId)){
-          track.releasePointerCapture(event.pointerId);
-        }
-        if(Math.abs(deltaX)>40){
-          deltaX>0?goPrev():goNext();
-          restartAutoplay();
-        }
-        deltaX=0;
-      };
-      track.addEventListener('pointerup',endPointer);
-      track.addEventListener('pointercancel',endPointer);
-
-      window.addEventListener('resize',()=>{
-        requestAnimationFrame(updateHeight);
-      });
-
-      document.addEventListener('visibilitychange',()=>{
-        if(!autoplayEnabled) return;
-        if(document.hidden){
-          clearInterval(autoplayTimer);
-        }else{
-          restartAutoplay();
-        }
-      });
-
-      setSlide(0);
-      window.addEventListener('load',()=>requestAnimationFrame(updateHeight));
-      restartAutoplay();
-    })();
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -245,6 +245,19 @@
       transform-origin: center bottom;
       transition: transform .6s ease;
     }
+    .newsletter-inbox::after{
+      content: "";
+      position: absolute;
+      bottom: -1.3rem;
+      left: -20%;
+      width: 140%;
+      height: 3px;
+      background: linear-gradient(95deg, rgba(255,255,255,0) 0%, rgba(255,255,255,.65) 45%, rgba(8,21,46,.7) 100%);
+      transform: rotate(-4deg);
+      opacity: .65;
+      pointer-events: none;
+      filter: blur(.3px);
+    }
     @media (min-width: 768px){
       .hero-media .newsletter-inbox{
         transform: rotateX(8deg) rotateY(12deg);
@@ -284,12 +297,20 @@
       border: 1px solid rgba(11,31,68,.15);
       box-shadow: 0 25px 55px rgba(5,16,32,.28);
       padding: .85rem 1.25rem;
-      max-width: calc(100% - 3rem);
+      width: calc(100% - 2rem);
+      max-width: 420px;
       font-size: .95rem;
       line-height: 1.4;
       display: flex;
       align-items: center;
       gap: .5rem;
+    }
+    @media (min-width: 1024px){
+      .hero-photo-alert{
+        font-size: 1rem;
+        padding: 1rem 1.75rem;
+        max-width: 480px;
+      }
     }
     .hero-photo-alert-label{
       font-weight: 600;
@@ -802,7 +823,7 @@
           slide.dataset.state=offset===0?'active':'inactive';
           slide.style.opacity=offset===0?'1':'0';
           slide.style.pointerEvents=offset===0?'auto':'none';
-          slide.style.transform=`translateY(${offset*110}%)`;
+          slide.style.transform=`translateX(${offset*110}%)`;
           slide.style.zIndex=String(slides.length-Math.abs(offset));
         });
         updateHeight();
@@ -830,21 +851,21 @@
       next?.addEventListener('click',()=>{goNext(); restartAutoplay();});
       dots.forEach((dot,i)=>dot.addEventListener('click',()=>{setSlide(i); restartAutoplay();}));
 
-      // Swipe gestures (vertical)
+      // Swipe gestures (horizontal)
       let pointerActive=false;
-      let startY=0;
-      let deltaY=0;
+      let startX=0;
+      let deltaX=0;
       track.addEventListener('pointerdown',(event)=>{
         pointerActive=true;
-        startY=event.clientY;
-        deltaY=0;
+        startX=event.clientX;
+        deltaX=0;
         if(track.setPointerCapture){
           track.setPointerCapture(event.pointerId);
         }
       });
       track.addEventListener('pointermove',(event)=>{
         if(!pointerActive) return;
-        deltaY=event.clientY-startY;
+        deltaX=event.clientX-startX;
       });
       const endPointer=(event)=>{
         if(!pointerActive) return;
@@ -852,11 +873,11 @@
         if(track.hasPointerCapture&&track.hasPointerCapture(event.pointerId)){
           track.releasePointerCapture(event.pointerId);
         }
-        if(Math.abs(deltaY)>40){
-          deltaY>0?goPrev():goNext();
+        if(Math.abs(deltaX)>40){
+          deltaX>0?goPrev():goNext();
           restartAutoplay();
         }
-        deltaY=0;
+        deltaX=0;
       };
       track.addEventListener('pointerup',endPointer);
       track.addEventListener('pointercancel',endPointer);

--- a/index.html
+++ b/index.html
@@ -149,6 +149,72 @@
       display: flex;
       justify-content: center;
       padding: 2rem 0 6rem;
+      perspective: 1400px;
+    }
+    .hero-carousel{
+      width: min(100%, 540px);
+      position: relative;
+    }
+    .hero-carousel-track{
+      display: flex;
+      transition: transform .6s ease;
+      will-change: transform;
+      overflow: visible;
+      touch-action: pan-y;
+    }
+    .hero-slide{
+      flex: 0 0 100%;
+      display: flex;
+      justify-content: center;
+      padding-bottom: 3rem;
+    }
+    .hero-carousel-nav{
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 1.5rem;
+      margin-top: 1.25rem;
+    }
+    .hero-carousel-button{
+      width: 2.5rem;
+      height: 2.5rem;
+      border-radius: 9999px;
+      border: 1px solid rgba(255,255,255,.28);
+      background: rgba(255,255,255,.14);
+      color: #f6fbff;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      font-size: 1.15rem;
+      transition: background .3s ease, border-color .3s ease;
+    }
+    .hero-carousel-button:hover{
+      background: rgba(255,255,255,.24);
+      border-color: rgba(255,255,255,.45);
+    }
+    .hero-carousel-button:focus{
+      outline: 2px solid var(--accent-soft);
+      outline-offset: 2px;
+    }
+    .hero-carousel-dots{
+      display: flex;
+      align-items: center;
+      gap: .65rem;
+    }
+    .hero-carousel-dot{
+      width: .75rem;
+      height: .75rem;
+      border-radius: 9999px;
+      border: 0;
+      background: rgba(255,255,255,.28);
+      cursor: pointer;
+      transition: background .3s ease, width .3s ease;
+    }
+    .hero-carousel-dot[aria-current="true"]{
+      background: var(--accent);
+      width: 1.45rem;
     }
     .newsletter-inbox{
       width: min(100%, 520px);
@@ -161,6 +227,59 @@
       display: flex;
       flex-direction: column;
       gap: 1.5rem;
+      position: relative;
+      -webkit-box-reflect: below 1.5rem linear-gradient(transparent 45%, rgba(5,16,32,.35));
+      transform-origin: center bottom;
+      transition: transform .6s ease;
+    }
+    @media (min-width: 768px){
+      .hero-media .newsletter-inbox{
+        transform: rotateX(8deg) rotateY(-12deg);
+      }
+    }
+    @media (min-width: 1024px){
+      .hero-media{
+        perspective: 2000px;
+      }
+      .hero-media .newsletter-inbox{
+        transform: rotateX(10deg) rotateY(-16deg);
+      }
+    }
+    .hero-photo-card{
+      position: relative;
+      width: min(100%, 520px);
+      border-radius: 1.75rem;
+      overflow: hidden;
+      box-shadow: 0 40px 90px rgba(4,14,30,.35);
+      border: 1px solid rgba(255,255,255,.25);
+    }
+    .hero-photo-card img{
+      width: 100%;
+      height: 100%;
+      max-height: 520px;
+      object-fit: cover;
+      display: block;
+    }
+    .hero-photo-alert{
+      position: absolute;
+      left: 50%;
+      bottom: 1.75rem;
+      transform: translateX(-50%);
+      background: rgba(255,255,255,.92);
+      color: #0b1f44;
+      border-radius: 1rem;
+      border: 1px solid rgba(11,31,68,.15);
+      box-shadow: 0 25px 55px rgba(5,16,32,.28);
+      padding: .85rem 1.25rem;
+      max-width: calc(100% - 3rem);
+      font-size: .95rem;
+      line-height: 1.4;
+      display: flex;
+      align-items: center;
+      gap: .5rem;
+    }
+    .hero-photo-alert-label{
+      font-weight: 600;
     }
     .inbox-status{
       display: flex;
@@ -385,50 +504,78 @@
       </div>
 
       <div class="hero-media">
-        <div class="newsletter-inbox">
-          <div class="inbox-status">
-            <span>Inbox · Today</span>
-            <span>3 new</span>
-          </div>
-          <div class="newsletter-email">
-            <div class="email-meta">
-              <div class="email-avatar">C</div>
-              <div>
-                <p class="email-from">Cruisora</p>
-                <p class="email-to">to alicia@email.com</p>
+        <div class="hero-carousel" data-hero-carousel data-autoplay="true">
+          <div class="hero-carousel-track" data-hero-track>
+            <div class="hero-slide" data-hero-slide>
+              <div class="newsletter-inbox">
+                <div class="inbox-status">
+                  <span>Inbox · Today</span>
+                  <span>3 new</span>
+                </div>
+                <div class="newsletter-email">
+                  <div class="email-meta">
+                    <div class="email-avatar">C</div>
+                    <div>
+                      <p class="email-from">Cruisora</p>
+                      <p class="email-to">to alicia@email.com</p>
+                    </div>
+                    <span class="email-time">9:12 AM</span>
+                  </div>
+                  <div>
+                    <div class="email-subject">Your weekly cruise picks just docked 🚢</div>
+                    <p class="email-intro">Hi Alicia, we scanned hundreds of sailings and pulled the matches that fit your saved ships and budget.</p>
+                  </div>
+                  <ul class="newsletter-deal-list">
+                    <li class="newsletter-deal">
+                      <div>
+                        <div class="deal-route">Barcelona ➜ Greek Isles</div>
+                        <div class="deal-details">7 nights · Celebrity Ascent · July 2025</div>
+                      </div>
+                      <span class="deal-tag">Save 22%</span>
+                    </li>
+                    <li class="newsletter-deal">
+                      <div>
+                        <div class="deal-route">Miami Escape &amp; CocoCay</div>
+                        <div class="deal-details">4 nights · Icon of the Seas · Spring 2025</div>
+                      </div>
+                      <span class="deal-tag">From $389</span>
+                    </li>
+                    <li class="newsletter-deal">
+                      <div>
+                        <div class="deal-route">Alaska Glacier Vista</div>
+                        <div class="deal-details">10 nights · Princess Discovery · August 2025</div>
+                      </div>
+                      <span class="deal-tag">New cabins</span>
+                    </li>
+                  </ul>
+                  <button type="button" class="email-cta">View all deals</button>
+                </div>
+                <p class="email-footer-note">Sent from your Cruisora watchlist alerts</p>
               </div>
-              <span class="email-time">9:12 AM</span>
             </div>
-            <div>
-              <div class="email-subject">Your weekly cruise picks just docked 🚢</div>
-              <p class="email-intro">Hi Alicia, we scanned hundreds of sailings and pulled the matches that fit your saved ships and budget.</p>
+            <div class="hero-slide" data-hero-slide>
+              <div class="hero-photo-card">
+                <img src="https://images.unsplash.com/photo-1533105079780-92b9be482077?auto=format&fit=crop&w=1600&q=80"
+                     alt="Cruise ship gliding through the Greek Isles" referrerpolicy="no-referrer">
+                <div class="hero-photo-alert">
+                  <span class="hero-photo-alert-label">🔔 Smart alert:</span>
+                  <span>Price dropped 18% on your saved Europe sailing.</span>
+                </div>
+              </div>
             </div>
-            <ul class="newsletter-deal-list">
-              <li class="newsletter-deal">
-                <div>
-                  <div class="deal-route">Barcelona ➜ Greek Isles</div>
-                  <div class="deal-details">7 nights · Celebrity Ascent · July 2025</div>
-                </div>
-                <span class="deal-tag">Save 22%</span>
-              </li>
-              <li class="newsletter-deal">
-                <div>
-                  <div class="deal-route">Miami Escape &amp; CocoCay</div>
-                  <div class="deal-details">4 nights · Icon of the Seas · Spring 2025</div>
-                </div>
-                <span class="deal-tag">From $389</span>
-              </li>
-              <li class="newsletter-deal">
-                <div>
-                  <div class="deal-route">Alaska Glacier Vista</div>
-                  <div class="deal-details">10 nights · Princess Discovery · August 2025</div>
-                </div>
-                <span class="deal-tag">New cabins</span>
-              </li>
-            </ul>
-            <button type="button" class="email-cta">View all deals</button>
           </div>
-          <p class="email-footer-note">Sent from your Cruisora watchlist alerts</p>
+          <div class="hero-carousel-nav">
+            <button type="button" class="hero-carousel-button" data-hero-prev aria-label="Previous hero slide">
+              <span aria-hidden="true">‹</span>
+            </button>
+            <div class="hero-carousel-dots" role="tablist" aria-label="Hero slides">
+              <button type="button" class="hero-carousel-dot" aria-label="Show hero slide 1" aria-current="true" data-hero-dot="0"></button>
+              <button type="button" class="hero-carousel-dot" aria-label="Show hero slide 2" data-hero-dot="1"></button>
+            </div>
+            <button type="button" class="hero-carousel-button" data-hero-next aria-label="Next hero slide">
+              <span aria-hidden="true">›</span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -612,6 +759,86 @@
         setTimeout(()=>{banner.classList.add('opacity-0'); setTimeout(()=>banner.classList.add('hidden'),400)},3500);};
       new MutationObserver(()=>{const vis=successEl.style.display!=='none'; if(vis){show();}})
         .observe(successEl,{childList:true,subtree:true,attributes:true,characterData:true});
+    })();
+
+    // Hero carousel logic
+    (function(){
+      const carousel=document.querySelector('[data-hero-carousel]');
+      if(!carousel) return;
+      const track=carousel.querySelector('[data-hero-track]');
+      const slides=[...carousel.querySelectorAll('[data-hero-slide]')];
+      const dots=[...carousel.querySelectorAll('[data-hero-dot]')];
+      const prev=carousel.querySelector('[data-hero-prev]');
+      const next=carousel.querySelector('[data-hero-next]');
+      if(!track||slides.length<=1) return;
+      let index=0;
+      let autoplayTimer;
+      const prefersReduced=window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      const autoplayEnabled=carousel.hasAttribute('data-autoplay')&&!prefersReduced;
+
+      const setSlide=(nextIndex)=>{
+        index=(nextIndex+slides.length)%slides.length;
+        track.style.transform=`translateX(-${index*100}%)`;
+        dots.forEach((dot,i)=>{
+          dot.setAttribute('aria-current', i===index ? 'true' : 'false');
+        });
+      };
+
+      const goNext=()=>setSlide(index+1);
+      const goPrev=()=>setSlide(index-1);
+
+      const restartAutoplay=()=>{
+        if(!autoplayEnabled) return;
+        clearInterval(autoplayTimer);
+        autoplayTimer=setInterval(goNext,6000);
+      };
+
+      prev?.addEventListener('click',()=>{goPrev(); restartAutoplay();});
+      next?.addEventListener('click',()=>{goNext(); restartAutoplay();});
+      dots.forEach((dot,i)=>dot.addEventListener('click',()=>{setSlide(i); restartAutoplay();}));
+
+      // Swipe gestures
+      let pointerActive=false;
+      let startX=0;
+      let deltaX=0;
+      track.addEventListener('pointerdown',(event)=>{
+        pointerActive=true;
+        startX=event.clientX;
+        deltaX=0;
+        if(track.setPointerCapture){
+          track.setPointerCapture(event.pointerId);
+        }
+      });
+      track.addEventListener('pointermove',(event)=>{
+        if(!pointerActive) return;
+        deltaX=event.clientX-startX;
+      });
+      const endPointer=(event)=>{
+        if(!pointerActive) return;
+        pointerActive=false;
+        if(track.hasPointerCapture&&track.hasPointerCapture(event.pointerId)){
+          track.releasePointerCapture(event.pointerId);
+        }
+        if(Math.abs(deltaX)>40){
+          deltaX>0?goPrev():goNext();
+          restartAutoplay();
+        }
+        deltaX=0;
+      };
+      track.addEventListener('pointerup',endPointer);
+      track.addEventListener('pointercancel',endPointer);
+
+      document.addEventListener('visibilitychange',()=>{
+        if(!autoplayEnabled) return;
+        if(document.hidden){
+          clearInterval(autoplayTimer);
+        }else{
+          restartAutoplay();
+        }
+      });
+
+      setSlide(0);
+      restartAutoplay();
     })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add perspective to the hero media wrapper so the mockup reads more like a phone in space
- tilt the newsletter inbox card while retaining the glass reflection treatment
- introduce a two-slide hero carousel that cycles between the tilted inbox mockup and the Greek Isles photo with the smart alert overlay

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e33117893c832dad90300067e20807