### PR TITLE
Add standalone privacy policy and terms pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -601,7 +601,7 @@
   <footer class="border-t border-slate-200 bg-white">
     <div class="mx-auto max-w-6xl px-4 py-10 text-sm text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <div class="space-y-2 sm:space-y-1">
-        <p>© <span id="y"></span> cruisora • <a class="hover:underline" href="#">Privacy</a> • <a class="hover:underline" href="#">Terms</a></p>
+        <p>© <span id="y"></span> cruisora • <a class="hover:underline" href="privacy.html">Privacy</a> • <a class="hover:underline" href="terms.html">Terms</a></p>
         <p class="text-slate-500">Cruisora • <a class="hover:underline" href="tel:13056976080">305.697.6080</a> • <a class="hover:underline" href="mailto:hello@cruisora.com">hello@cruisora.com</a></p>
         <nav class="flex flex-wrap gap-x-4 gap-y-2 text-slate-500">
           <a class="hover:underline" href="#">Careers</a>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,207 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Cruisora Privacy Policy</title>
+  <meta name="description" content="Learn how Cruisora collects, uses, and protects your information across our website, app, and newsletters." />
+  <link rel="canonical" href="https://cruisora.com/privacy" />
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Cruisora Privacy Policy" />
+  <meta property="og:description" content="Understand the data we collect, how we use it, and the rights available to you as a Cruisora customer." />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://images.unsplash.com/photo-1533105079780-92b9be482077?q=80&w=1600&auto=format&fit=crop" />
+  <meta property="og:image:alt" content="Cruise ship in turquoise Caribbean water" />
+  <meta property="og:url" content="https://cruisora.com/privacy" />
+  <meta name="twitter:card" content="summary_large_image" />
+
+  <!-- Tailwind via CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- Typography -->
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{
+      --brand:#0b1f44;
+      --brand-ink:#0a162e;
+      --accent:#14c7e8;
+      --accent-strong:#0bb0cf;
+      --accent-soft:#8ee8f7;
+      --ink:#0b1220;
+      --brand-faint: rgba(11,31,68,0.06);
+    }
+    h1, h2, h3, h4, .heading {
+      font-family: "DM Sans", "Helvetica Neue", Helvetica, Arial, system-ui, sans-serif;
+      font-weight: 700;
+      letter-spacing: -0.015em;
+      color: var(--brand);
+    }
+    body {
+      font-family: "Helvetica Neue", Helvetica, Arial, "DM Sans", system-ui, sans-serif;
+      color: var(--brand-ink);
+      font-weight: 400;
+      letter-spacing: -0.01em;
+      background-color: #ffffff;
+    }
+    .hero-bg{
+      background:
+        radial-gradient(800px 400px at 10% -10%, rgba(20,199,232,.18), transparent),
+        radial-gradient(900px 500px at 110% 10%, rgba(11,31,68,.70), rgba(11,31,68,.95));
+      position: relative;
+      isolation: isolate;
+    }
+    .hero-bg::before{
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(125deg, rgba(5,12,26,.88) 0%, rgba(5,14,30,.82) 45%, rgba(11,31,68,.55) 75%, rgba(20,199,232,.15) 100%);
+      z-index: 0;
+    }
+    .hero-bg > *{ position: relative; z-index: 1; }
+    .hero-copy{
+      background: linear-gradient(140deg, rgba(8,21,46,.86), rgba(8,28,54,.78));
+      border-radius: 1.75rem;
+      padding: 2.25rem;
+      border: 1px solid rgba(255,255,255,.12);
+      box-shadow: 0 30px 70px rgba(4,11,24,.45);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+    }
+    .hero-copy h1{ color: #f6fbff; }
+    .hero-copy p{ color: rgba(255,255,255,.9); }
+  </style>
+</head>
+<body class="min-h-screen flex flex-col bg-white">
+  <header class="border-b border-slate-200 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/80">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
+      <a class="text-lg font-semibold text-slate-800" href="index.html">cruisora</a>
+      <nav class="hidden gap-6 text-sm font-medium text-slate-600 sm:flex">
+        <a class="hover:text-slate-900" href="index.html#features">Features</a>
+        <a class="hover:text-slate-900" href="index.html#waitlist">Join waitlist</a>
+        <a class="hover:text-slate-900" href="terms.html">Terms</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="flex-1">
+    <section class="hero-bg">
+      <div class="mx-auto flex max-w-6xl flex-col gap-12 px-4 py-24 text-slate-100 md:flex-row md:items-center md:justify-between">
+        <div class="hero-copy max-w-xl">
+          <p class="mb-4 text-sm font-semibold uppercase tracking-[0.3em] text-accent-soft">Policy</p>
+          <h1 class="text-4xl sm:text-5xl">Cruisora Privacy Policy</h1>
+          <p class="mt-6 text-base leading-relaxed">Effective Date: October 5, 2025<br />Last Updated: October 5, 2025</p>
+        </div>
+        <div class="max-w-lg rounded-3xl border border-white/15 bg-white/10 p-6 text-sm leading-relaxed text-slate-100 shadow-2xl">
+          <p class="font-semibold text-white">Your privacy, protected.</p>
+          <p class="mt-3 text-slate-100/90">We safeguard your data with encryption, vetted partners, and transparent controls so you can plan cruises confidently.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-4xl space-y-12 px-4 py-16 text-slate-700">
+      <div class="space-y-4">
+        <h2 class="text-2xl">1. Introduction</h2>
+        <p>Cruisora LLC ("Cruisora," "we," "our," or "us") respects your privacy and is committed to protecting your personal information. This Privacy Policy explains how we collect, use, disclose, and protect your data when you use our website, mobile application ("App"), or subscribe to our email newsletters (collectively, the "Services"). By accessing or using our Services, you agree to the terms of this Privacy Policy.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">2. Information We Collect</h2>
+        <p>We may collect the following types of information from you:</p>
+        <ul class="list-disc space-y-2 pl-6">
+          <li>Name, email address, phone number, home and mailing address</li>
+          <li>Age, dining preferences, accessibility needs (e.g., wheelchair-accessible requirements)</li>
+          <li>Occupation or professional designation (e.g., EMT, emergency responder)</li>
+          <li>Veteran status</li>
+          <li>Payment and billing information</li>
+          <li>Device and browser data, cookies, and usage analytics</li>
+          <li>Referral and affiliate tracking data when you click on partner links</li>
+        </ul>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">3. How We Use Your Information</h2>
+        <p>We use your information to:</p>
+        <ul class="list-disc space-y-2 pl-6">
+          <li>Operate and improve our website, app, and newsletters</li>
+          <li>Personalize cruise recommendations and deals</li>
+          <li>Send you promotional and transactional messages</li>
+          <li>Notify you about new sailings, price changes, or matching itineraries</li>
+          <li>Process payments and fulfill services</li>
+          <li>Contact you by email, push notification, phone, or in-app messages</li>
+          <li>Comply with legal obligations and enforce our Terms</li>
+        </ul>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">4. Affiliate Disclosure</h2>
+        <p>Cruisora participates in affiliate marketing programs with travel partners. We may receive compensation for clicks, bookings, or purchases made through affiliate links in our site, emails, or app. This does not affect the price you pay or your experience with the partner.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">5. How We Share Information</h2>
+        <p>We may share your data with:</p>
+        <ul class="list-disc space-y-2 pl-6">
+          <li><span class="font-medium">Service Providers:</span> including Mailchimp (for newsletters), analytics, hosting, and payment processors</li>
+          <li><span class="font-medium">Affiliate Partners:</span> to facilitate bookings and track referrals</li>
+          <li><span class="font-medium">Legal Authorities:</span> when required to comply with laws or protect rights</li>
+        </ul>
+        <p>Cruisora does not sell personal information to third parties.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">6. Cookies and Tracking</h2>
+        <p>We use cookies and tracking tools to analyze traffic, personalize recommendations, and improve user experience. You can manage or disable cookies in your browser settings.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">7. Data Security and Retention</h2>
+        <p>We use encryption, secure servers, and limited access controls to safeguard personal data. We retain your data only as long as necessary to provide our Services or comply with legal requirements.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">8. Your Rights</h2>
+        <p>Depending on your jurisdiction, you may have the right to:</p>
+        <ul class="list-disc space-y-2 pl-6">
+          <li>Access, correct, or delete your data</li>
+          <li>Opt out of marketing communications</li>
+          <li>Request limitations on data processing</li>
+          <li>Withdraw consent at any time</li>
+        </ul>
+        <p>To exercise your rights, contact us at <a class="text-accent hover:underline" href="mailto:privacy@cruisora.com">privacy@cruisora.com</a>.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">9. Children’s Privacy</h2>
+        <p>Our Services are not directed to children under 18, and we do not knowingly collect their information.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">10. International Use</h2>
+        <p>Cruisora operates in the United States. By using our Services, you consent to the transfer and processing of your information in the U.S.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">11. Changes to This Policy</h2>
+        <p>We may update this Privacy Policy periodically. The latest version will always be available on our website and marked with the effective date above.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">12. Contact Us</h2>
+        <p>If you have questions or requests about this Privacy Policy, contact us at:</p>
+        <p class="leading-relaxed">Cruisora LLC<br />Atlanta, GA 30328<br />Email: <a class="text-accent hover:underline" href="mailto:privacy@cruisora.com">privacy@cruisora.com</a></p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-slate-200 bg-white">
+    <div class="mx-auto max-w-6xl px-4 py-8 text-sm text-slate-600">
+      <p>© <span id="y"></span> cruisora • <a class="hover:underline" href="privacy.html">Privacy</a> • <a class="hover:underline" href="terms.html">Terms</a></p>
+      <p class="mt-2 text-slate-500">Return to the <a class="hover:underline" href="index.html">home page</a>.</p>
+    </div>
+  </footer>
+
+  <script>document.getElementById('y').textContent=new Date().getFullYear();</script>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Cruisora Terms &amp; Conditions</title>
+  <meta name="description" content="Review the Terms and Conditions that govern your use of Cruisora’s website, app, and newsletters." />
+  <link rel="canonical" href="https://cruisora.com/terms" />
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Cruisora Terms &amp; Conditions" />
+  <meta property="og:description" content="Understand the rules for using Cruisora’s cruise discovery tools and communications." />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://images.unsplash.com/photo-1533105079780-92b9be482077?q=80&w=1600&auto=format&fit=crop" />
+  <meta property="og:image:alt" content="Cruise ship in turquoise Caribbean water" />
+  <meta property="og:url" content="https://cruisora.com/terms" />
+  <meta name="twitter:card" content="summary_large_image" />
+
+  <!-- Tailwind via CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- Typography -->
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{
+      --brand:#0b1f44;
+      --brand-ink:#0a162e;
+      --accent:#14c7e8;
+      --accent-strong:#0bb0cf;
+      --accent-soft:#8ee8f7;
+      --ink:#0b1220;
+      --brand-faint: rgba(11,31,68,0.06);
+    }
+    h1, h2, h3, h4, .heading {
+      font-family: "DM Sans", "Helvetica Neue", Helvetica, Arial, system-ui, sans-serif;
+      font-weight: 700;
+      letter-spacing: -0.015em;
+      color: var(--brand);
+    }
+    body {
+      font-family: "Helvetica Neue", Helvetica, Arial, "DM Sans", system-ui, sans-serif;
+      color: var(--brand-ink);
+      font-weight: 400;
+      letter-spacing: -0.01em;
+      background-color: #ffffff;
+    }
+    .hero-bg{
+      background:
+        radial-gradient(800px 400px at 10% -10%, rgba(20,199,232,.18), transparent),
+        radial-gradient(900px 500px at 110% 10%, rgba(11,31,68,.70), rgba(11,31,68,.95));
+      position: relative;
+      isolation: isolate;
+    }
+    .hero-bg::before{
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(125deg, rgba(5,12,26,.88) 0%, rgba(5,14,30,.82) 45%, rgba(11,31,68,.55) 75%, rgba(20,199,232,.15) 100%);
+      z-index: 0;
+    }
+    .hero-bg > *{ position: relative; z-index: 1; }
+    .hero-copy{
+      background: linear-gradient(140deg, rgba(8,21,46,.86), rgba(8,28,54,.78));
+      border-radius: 1.75rem;
+      padding: 2.25rem;
+      border: 1px solid rgba(255,255,255,.12);
+      box-shadow: 0 30px 70px rgba(4,11,24,.45);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+    }
+    .hero-copy h1{ color: #f6fbff; }
+    .hero-copy p{ color: rgba(255,255,255,.9); }
+  </style>
+</head>
+<body class="min-h-screen flex flex-col bg-white">
+  <header class="border-b border-slate-200 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/80">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
+      <a class="text-lg font-semibold text-slate-800" href="index.html">cruisora</a>
+      <nav class="hidden gap-6 text-sm font-medium text-slate-600 sm:flex">
+        <a class="hover:text-slate-900" href="index.html#features">Features</a>
+        <a class="hover:text-slate-900" href="index.html#waitlist">Join waitlist</a>
+        <a class="hover:text-slate-900" href="privacy.html">Privacy</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="flex-1">
+    <section class="hero-bg">
+      <div class="mx-auto flex max-w-6xl flex-col gap-12 px-4 py-24 text-slate-100 md:flex-row md:items-center md:justify-between">
+        <div class="hero-copy max-w-xl">
+          <p class="mb-4 text-sm font-semibold uppercase tracking-[0.3em] text-accent-soft">Terms</p>
+          <h1 class="text-4xl sm:text-5xl">Cruisora Terms &amp; Conditions</h1>
+          <p class="mt-6 text-base leading-relaxed">Effective Date: October 5, 2025<br />Last Updated: October 5, 2025</p>
+        </div>
+        <div class="max-w-lg rounded-3xl border border-white/15 bg-white/10 p-6 text-sm leading-relaxed text-slate-100 shadow-2xl">
+          <p class="font-semibold text-white">Know the rules of the voyage.</p>
+          <p class="mt-3 text-slate-100/90">These terms outline how to use Cruisora, interact with partners, and stay informed about changes.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-4xl space-y-12 px-4 py-16 text-slate-700">
+      <p>By using Cruisora’s website, app, or newsletters ("Services"), you agree to these Terms and Conditions ("Terms"). If you do not agree, please discontinue use of the Services.</p>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">1. Acceptance of Terms</h2>
+        <p>By accessing or using the Services, you accept and agree to be bound by these Terms. If you do not agree, please do not use the Services.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">2. Overview</h2>
+        <p>Cruisora LLC provides tools to explore, compare, and track cruise sailings. We are not a travel agency and do not directly sell cruises. Some links on our platform are affiliate links through which we may earn compensation for clicks, bookings, or purchases.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">3. User Accounts</h2>
+        <ul class="list-disc space-y-2 pl-6">
+          <li>You may create an account to access features such as saved searches, watchlists, and alerts.</li>
+          <li>You agree to provide accurate, current, and complete information.</li>
+          <li>You are responsible for maintaining the confidentiality of your login details.</li>
+        </ul>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">4. Permitted Use</h2>
+        <p>You agree to use our Services only for lawful purposes. You may not:</p>
+        <ul class="list-disc space-y-2 pl-6">
+          <li>Use our Services for fraudulent or misleading activity</li>
+          <li>Interfere with or disrupt our systems or networks</li>
+          <li>Reverse-engineer, copy, or resell any part of our Services or data without written consent</li>
+        </ul>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">5. Intellectual Property</h2>
+        <p>All trademarks, graphics, text, and design elements on Cruisora’s website and app are owned by Cruisora LLC or licensed to us. You may not reproduce or distribute our materials without permission.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">6. Affiliate and Third-Party Links</h2>
+        <p>Cruisora contains affiliate links to third-party travel partners. We are not responsible for the content, pricing, or privacy practices of third-party websites. Bookings or purchases made through those links are governed by the terms of the respective partner.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">7. Communications</h2>
+        <p>By registering with Cruisora, you consent to receive communications via email, push notifications, phone, or in-app messages. You may opt out at any time by unsubscribing or adjusting your account settings.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">8. Payment Terms</h2>
+        <p>If you make a payment through Cruisora for premium features or other services, transactions are securely processed by third-party providers. You agree to their respective terms and conditions.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">9. Disclaimer of Warranties</h2>
+        <p>Cruisora’s Services are provided “as is” and “as available.” We make no warranties, express or implied, regarding accuracy, availability, or reliability of the information provided.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">10. Limitation of Liability</h2>
+        <p>To the fullest extent permitted by law, Cruisora LLC and its affiliates are not liable for any indirect, incidental, consequential, or punitive damages arising from your use of the Services.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">11. Indemnification</h2>
+        <p>You agree to indemnify and hold harmless Cruisora LLC and its officers from any claims, damages, or expenses resulting from your use of the Services or violation of these Terms.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">12. Governing Law</h2>
+        <p>These Terms are governed by the laws of the United States and the State of Georgia, without regard to conflict of law principles.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">13. Termination</h2>
+        <p>Cruisora may suspend or terminate your account or access at any time for violation of these Terms or any unlawful or abusive activity.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">14. Changes to Terms</h2>
+        <p>Cruisora may revise these Terms from time to time. Updates will be effective immediately upon posting. Your continued use constitutes acceptance of any changes.</p>
+      </div>
+
+      <div class="space-y-4">
+        <h2 class="text-2xl">15. Contact Us</h2>
+        <p>If you have questions about these Terms, contact us at:</p>
+        <p class="leading-relaxed">Cruisora LLC<br />Atlanta, GA 30328<br />Email: <a class="text-accent hover:underline" href="mailto:support@cruisora.com">support@cruisora.com</a></p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-slate-200 bg-white">
+    <div class="mx-auto max-w-6xl px-4 py-8 text-sm text-slate-600">
+      <p>© <span id="y"></span> cruisora • <a class="hover:underline" href="privacy.html">Privacy</a> • <a class="hover:underline" href="terms.html">Terms</a></p>
+      <p class="mt-2 text-slate-500">Return to the <a class="hover:underline" href="index.html">home page</a>.</p>
+    </div>
+  </footer>
+
+  <script>document.getElementById('y').textContent=new Date().getFullYear();</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated Privacy Policy and Terms & Conditions landing pages that match the existing site styling
- populate each page with the applicable policy and terms content, including affiliate disclosures and contact details
- link the new pages from the footer so visitors can easily access them from the home page

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e33957df10832d99ae02a25bea0811