### PR TITLE
Align legal page headers with homepage branding

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -74,28 +74,28 @@
   </style>
 </head>
 <body class="min-h-screen flex flex-col bg-white">
-  <header class="border-b border-slate-200 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/80">
-    <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
-      <a class="text-lg font-semibold text-slate-800" href="index.html">cruisora</a>
-      <nav class="hidden gap-6 text-sm font-medium text-slate-600 sm:flex">
-        <a class="hover:text-slate-900" href="index.html#features">Features</a>
-        <a class="hover:text-slate-900" href="index.html#waitlist">Join waitlist</a>
-        <a class="hover:text-slate-900" href="terms.html">Terms</a>
+  <header class="border-b border-slate-200 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/60 sticky top-0 z-40">
+    <div class="mx-auto max-w-6xl px-4 py-4 flex items-center justify-between">
+      <a href="index.html" class="flex items-center gap-3">
+        <img src="/assets/cruisoralogo.png" alt="Cruisora logo" class="h-9 w-auto">
+      </a>
+      <nav class="hidden sm:flex gap-6 text-sm items-center">
+        <span class="text-slate-500">The <strong>app</strong> for smarter cruise shopping</span>
+        <a href="index.html#waitlist" class="hover:underline text-slate-700 font-semibold">Join Waitlist</a>
+        <a href="index.html#how" class="hover:underline text-slate-700 font-semibold">How It Works</a>
+        <a href="#" class="text-slate-300 pointer-events-none font-semibold">Download (coming soon)</a>
       </nav>
     </div>
   </header>
 
   <main class="flex-1">
     <section class="hero-bg">
-      <div class="mx-auto flex max-w-6xl flex-col gap-12 px-4 py-24 text-slate-100 md:flex-row md:items-center md:justify-between">
-        <div class="hero-copy max-w-xl">
-          <p class="mb-4 text-sm font-semibold uppercase tracking-[0.3em] text-accent-soft">Policy</p>
-          <h1 class="text-4xl sm:text-5xl">Cruisora Privacy Policy</h1>
-          <p class="mt-6 text-base leading-relaxed">Effective Date: October 5, 2025<br />Last Updated: October 5, 2025</p>
-        </div>
-        <div class="max-w-lg rounded-3xl border border-white/15 bg-white/10 p-6 text-sm leading-relaxed text-slate-100 shadow-2xl">
-          <p class="font-semibold text-white">Your privacy, protected.</p>
-          <p class="mt-3 text-slate-100/90">We safeguard your data with encryption, vetted partners, and transparent controls so you can plan cruises confidently.</p>
+      <div class="mx-auto max-w-4xl px-4 py-16 text-center text-slate-100 sm:py-20">
+        <div class="hero-copy mx-auto flex max-w-3xl flex-col gap-4 text-left sm:text-center">
+          <p class="text-xs font-semibold uppercase tracking-[0.3em] text-accent-soft">Policy</p>
+          <h1 class="text-3xl sm:text-4xl">Cruisora Privacy Policy</h1>
+          <p class="text-sm text-white/80">Effective Date: October 5, 2025 · Last Updated: October 5, 2025</p>
+          <p class="text-base leading-relaxed text-white/90">We safeguard your data with encryption, vetted partners, and transparent controls so you can plan cruises confidently.</p>
         </div>
       </div>
     </section>

--- a/terms.html
+++ b/terms.html
@@ -74,28 +74,28 @@
   </style>
 </head>
 <body class="min-h-screen flex flex-col bg-white">
-  <header class="border-b border-slate-200 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/80">
-    <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
-      <a class="text-lg font-semibold text-slate-800" href="index.html">cruisora</a>
-      <nav class="hidden gap-6 text-sm font-medium text-slate-600 sm:flex">
-        <a class="hover:text-slate-900" href="index.html#features">Features</a>
-        <a class="hover:text-slate-900" href="index.html#waitlist">Join waitlist</a>
-        <a class="hover:text-slate-900" href="privacy.html">Privacy</a>
+  <header class="border-b border-slate-200 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/60 sticky top-0 z-40">
+    <div class="mx-auto max-w-6xl px-4 py-4 flex items-center justify-between">
+      <a href="index.html" class="flex items-center gap-3">
+        <img src="/assets/cruisoralogo.png" alt="Cruisora logo" class="h-9 w-auto">
+      </a>
+      <nav class="hidden sm:flex gap-6 text-sm items-center">
+        <span class="text-slate-500">The <strong>app</strong> for smarter cruise shopping</span>
+        <a href="index.html#waitlist" class="hover:underline text-slate-700 font-semibold">Join Waitlist</a>
+        <a href="index.html#how" class="hover:underline text-slate-700 font-semibold">How It Works</a>
+        <a href="#" class="text-slate-300 pointer-events-none font-semibold">Download (coming soon)</a>
       </nav>
     </div>
   </header>
 
   <main class="flex-1">
     <section class="hero-bg">
-      <div class="mx-auto flex max-w-6xl flex-col gap-12 px-4 py-24 text-slate-100 md:flex-row md:items-center md:justify-between">
-        <div class="hero-copy max-w-xl">
-          <p class="mb-4 text-sm font-semibold uppercase tracking-[0.3em] text-accent-soft">Terms</p>
-          <h1 class="text-4xl sm:text-5xl">Cruisora Terms &amp; Conditions</h1>
-          <p class="mt-6 text-base leading-relaxed">Effective Date: October 5, 2025<br />Last Updated: October 5, 2025</p>
-        </div>
-        <div class="max-w-lg rounded-3xl border border-white/15 bg-white/10 p-6 text-sm leading-relaxed text-slate-100 shadow-2xl">
-          <p class="font-semibold text-white">Know the rules of the voyage.</p>
-          <p class="mt-3 text-slate-100/90">These terms outline how to use Cruisora, interact with partners, and stay informed about changes.</p>
+      <div class="mx-auto max-w-4xl px-4 py-16 text-center text-slate-100 sm:py-20">
+        <div class="hero-copy mx-auto flex max-w-3xl flex-col gap-4 text-left sm:text-center">
+          <p class="text-xs font-semibold uppercase tracking-[0.3em] text-accent-soft">Terms</p>
+          <h1 class="text-3xl sm:text-4xl">Cruisora Terms &amp; Conditions</h1>
+          <p class="text-sm text-white/80">Effective Date: October 5, 2025 · Last Updated: October 5, 2025</p>
+          <p class="text-base leading-relaxed text-white/90">Understand how to use Cruisora, interact with partners, and stay informed about updates to our services.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add the Cruisora logo and consistent navigation links to the privacy and terms headers
- simplify the privacy and terms hero sections to a condensed single-column layout

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e33d5f9518832db6966691aae7a730