### PR TITLE
Add HTML email template for cruise deals

### DIFF
--- a/email-template.html
+++ b/email-template.html
@@ -4,44 +4,38 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Cruisora Deals Email</title>
+    <title>Cruisora Weekly Wave</title>
     <style>
-      /* Email client resets */
-      body { margin: 0 !important; padding: 0 !important; }
+      body { margin: 0 !important; padding: 0 !important; background-color: #0b1f44; }
       table, td { border-collapse: collapse; }
-      img { border: 0; line-height: 100%; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; }
+      img { border: 0; line-height: 100%; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; display: block; }
       a { text-decoration: none; }
-
-      /* Force link colors to brand ink on iOS */
       .apple-link a { color: inherit !important; text-decoration: none !important; }
-
-      /* Dark mode overrides */
       @media (prefers-color-scheme: dark) {
         body, table, .email-body { background-color: #050c1a !important; }
-        .card { background-color: rgba(11,31,68,0.76) !important; }
-        .card-copy, .footer-copy { color: #eef7ff !important; }
+        .card { background-color: rgba(11, 31, 68, 0.82) !important; border-color: rgba(20, 199, 232, 0.14) !important; }
+        .card-title { color: #f6fbff !important; }
+        .card-copy, .footer-copy { color: rgba(238, 247, 255, 0.92) !important; }
       }
-
-      /* Desktop adjustments */
       @media screen and (min-width: 640px) {
         .stack-column { display: table-cell !important; max-width: 50% !important; }
-        .stack-column--third { max-width: 33.333% !important; }
+        .stack-column--quarter { max-width: 25% !important; }
       }
     </style>
   </head>
   <body style="margin:0; padding:0; background-color:#0b1f44;">
     <center style="width:100%; background:#0b1f44;">
-      <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:radial-gradient(600px 420px at 12% -10%, rgba(20,199,232,0.20), transparent), radial-gradient(900px 500px at 115% 0%, rgba(11,31,68,0.88), rgba(11,31,68,0.98));">
+      <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:radial-gradient(620px 420px at 15% -10%, rgba(20,199,232,0.20), transparent), radial-gradient(980px 560px at 120% -10%, rgba(11,31,68,0.88), rgba(11,31,68,0.98));">
         <tr>
-          <td align="center" style="padding:32px 16px 24px;">
-            <table role="presentation" cellpadding="0" cellspacing="0" width="600" class="email-body" style="width:100%; max-width:600px; background:linear-gradient(140deg, rgba(8,21,46,0.86), rgba(8,28,54,0.78)); border-radius:28px; border:1px solid rgba(255,255,255,0.12); box-shadow:0 30px 70px rgba(4,11,24,0.45);">
+          <td align="center" style="padding:32px 16px;">
+            <table role="presentation" cellpadding="0" cellspacing="0" width="600" class="email-body" style="width:100%; max-width:600px; background:linear-gradient(140deg, rgba(8,21,46,0.86), rgba(8,28,54,0.78)); border-radius:28px; border:1px solid rgba(255,255,255,0.12); box-shadow:0 30px 70px rgba(4,11,24,0.45); overflow:hidden;">
               <tr>
-                <td style="padding:40px 40px 32px; text-align:left;">
+                <td style="padding:36px 40px 28px;">
                   <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
                     <tr>
                       <td style="text-align:left;">
                         <a href="https://cruisora.com" style="display:inline-block;">
-                          <img src="https://cruisora.com/assets/cruisoralogo.png" alt="Cruisora" width="148" style="display:block; width:148px; max-width:100%; height:auto;" />
+                          <img src="https://cruisora.com/assets/cruisoralogo.png" alt="Cruisora" width="148" style="width:148px; max-width:100%; height:auto;" />
                         </a>
                       </td>
                       <td style="text-align:right; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:13px; color:rgba(255,255,255,0.74); font-weight:600;">
@@ -53,18 +47,25 @@
                 </td>
               </tr>
               <tr>
+                <td style="padding:0 40px 32px;">
+                  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-radius:22px; overflow:hidden;">
+                    <tr>
+                      <td>
+                        <img src="https://images.unsplash.com/photo-1533105079780-92b9be482077?q=80&w=1280&auto=format&fit=crop" alt="Sunlit cruise ship cutting through teal Caribbean waters" width="520" style="width:100%; max-width:520px; height:auto;" />
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <tr>
                 <td style="padding:0 40px 36px;">
                   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:rgba(255,255,255,0.12); border-radius:22px;">
                     <tr>
-                      <td style="padding:36px 32px 40px; text-align:left;">
-                        <div style="font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:12px; letter-spacing:0.12em; text-transform:uppercase; color:rgba(255,255,255,0.62); font-weight:600; margin-bottom:12px;">This week's radar</div>
-                        <h1 style="margin:0 0 16px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:34px; line-height:1.12; color:#f6fbff; font-weight:700; letter-spacing:-0.02em;">Sail into savings on your next cruise getaway</h1>
-                        <p style="margin:0 0 24px; font-family:'Helvetica Neue',Arial,sans-serif; font-size:16px; line-height:1.6; color:rgba(255,255,255,0.9);">Handpicked itineraries with price-per-night comparisons, exclusive perks, and alerts that keep you ahead of the price drops. You're receiving these deals because you asked Cruisora to watch the seas for you.</p>
-                        <table role="presentation" cellpadding="0" cellspacing="0">
-                          <tr>
-                            <td style="border-radius:9999px; background:linear-gradient(135deg,#14c7e8,#0bb0cf);"><a href="https://cruisora.com" style="display:inline-block; padding:13px 26px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-weight:600; font-size:16px; color:#f8feff;">View all featured sailings →</a></td>
-                          </tr>
-                        </table>
+                      <td style="padding:32px 32px 36px; text-align:left;">
+                        <div style="font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:12px; letter-spacing:0.12em; text-transform:uppercase; color:rgba(255,255,255,0.62); font-weight:600; margin-bottom:12px;">This Week in Cruising</div>
+                        <h1 style="margin:0 0 16px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:34px; line-height:1.12; color:#f6fbff; font-weight:700; letter-spacing:-0.02em;">Cruisora Weekly Wave</h1>
+                        <p style="margin:0 0 12px; font-family:'Helvetica Neue',Arial,sans-serif; font-size:16px; line-height:1.6; color:rgba(255,255,255,0.9);">Royal Caribbean surprised cruisers with the announcement of a brand-new Icon-class ship debuting two months ahead of schedule, complete with an expanded adults-only suite enclave. Fleetwide upgrades are rippling out to shore, with Starlink-powered Wi-Fi now included on more than 60% of sailings.</p>
+                        <p style="margin:0; font-family:'Helvetica Neue',Arial,sans-serif; font-size:16px; line-height:1.6; color:rgba(255,255,255,0.9);">Ports are preparing for a record-breaking summer as Barcelona, Miami, and Vancouver clear new berths, and our data team is already spotting fare dips as cruise lines race to fill freshly added inventory. Consider this your heads-up to lock plans while the waves of savings roll in.</p>
                       </td>
                     </tr>
                   </table>
@@ -74,13 +75,16 @@
                 <td style="padding:0 40px 12px;">
                   <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
                     <tr>
+                      <td style="padding:0 0 18px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:18px; font-weight:700; color:#f6fbff;">Top Sail Picks We Love Right Now</td>
+                    </tr>
+                    <tr>
                       <td class="stack-column" style="display:block; width:100%; max-width:100%; padding-bottom:24px;">
                         <table role="presentation" width="100%" cellpadding="0" cellspacing="0" class="card" style="background:#ffffff; border-radius:20px; border:1px solid rgba(11,31,68,0.08); overflow:hidden;">
                           <tr>
                             <td style="padding:28px 28px 24px;">
                               <div style="font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:13px; letter-spacing:0.06em; text-transform:uppercase; color:#0bb0cf; font-weight:600;">7-night Caribbean</div>
-                              <h2 style="margin:10px 0 12px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:22px; line-height:1.25; color:#0b1f44;">Oasis of the Seas • July 14, 2024</h2>
-                              <p class="card-copy" style="margin:0 0 18px; font-family:'Helvetica Neue',Arial,sans-serif; font-size:15px; line-height:1.6; color:#0b1220;">Sail roundtrip from Miami and score a balcony upgrade with $200 onboard credit. Cruisora price radar shows fares down <strong style="color:#0bb0cf;">18%</strong> week-over-week.</p>
+                              <h2 class="card-title" style="margin:10px 0 12px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:22px; line-height:1.25; color:#0b1f44;">Icon of the Seas • July 14, 2024</h2>
+                              <p class="card-copy" style="margin:0 0 18px; font-family:'Helvetica Neue',Arial,sans-serif; font-size:15px; line-height:1.6; color:#0b1220;">Sail from Miami with AquaDome suites open for the very first season. Cruisora radar shows launch fares dipping <strong style="color:#0bb0cf;">12%</strong> as extra inventory hits the market.</p>
                               <table role="presentation" cellpadding="0" cellspacing="0">
                                 <tr>
                                   <td style="border-radius:9999px; background:rgba(20,199,232,0.1); border:1px solid rgba(20,199,232,0.35);"><a href="https://cruisora.com" style="display:inline-block; padding:10px 20px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-weight:600; font-size:14px; color:#0b1f44;">See sailing details</a></td>
@@ -97,8 +101,8 @@
                           <tr>
                             <td style="padding:28px 28px 24px;">
                               <div style="font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:13px; letter-spacing:0.06em; text-transform:uppercase; color:#0bb0cf; font-weight:600;">Mediterranean escape</div>
-                              <h2 style="margin:10px 0 12px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:22px; line-height:1.25; color:#0b1f44;">Celebrity Beyond • August 9, 2024</h2>
-                              <p class="card-copy" style="margin:0 0 18px; font-family:'Helvetica Neue',Arial,sans-serif; font-size:15px; line-height:1.6; color:#0b1220;">Rome to Barcelona with overnight in Marseille and a private Tuscan vineyard tour. Watchlist alert triggered a <strong style="color:#0bb0cf;">$420</strong> drop versus published rates.</p>
+                              <h2 class="card-title" style="margin:10px 0 12px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:22px; line-height:1.25; color:#0b1f44;">Celebrity Beyond • August 9, 2024</h2>
+                              <p class="card-copy" style="margin:0 0 18px; font-family:'Helvetica Neue',Arial,sans-serif; font-size:15px; line-height:1.6; color:#0b1220;">Rome to Barcelona with an overnight in Marseille and private Tuscan vineyard tour. Fare drop alerts flag a <strong style="color:#0bb0cf;">$420</strong> savings window through Sunday.</p>
                               <table role="presentation" cellpadding="0" cellspacing="0">
                                 <tr>
                                   <td style="border-radius:9999px; background:rgba(20,199,232,0.1); border:1px solid rgba(20,199,232,0.35);"><a href="https://cruisora.com" style="display:inline-block; padding:10px 20px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-weight:600; font-size:14px; color:#0b1f44;">See sailing details</a></td>
@@ -115,8 +119,26 @@
                           <tr>
                             <td style="padding:28px 28px 24px;">
                               <div style="font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:13px; letter-spacing:0.06em; text-transform:uppercase; color:#0bb0cf; font-weight:600;">Alaska adventure</div>
-                              <h2 style="margin:10px 0 12px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:22px; line-height:1.25; color:#0b1f44;">Norwegian Encore • September 1, 2024</h2>
-                              <p class="card-copy" style="margin:0 0 18px; font-family:'Helvetica Neue',Arial,sans-serif; font-size:15px; line-height:1.6; color:#0b1220;">Glacier Bay scenic cruising with free open bar and specialty dining. Fares trending <strong style="color:#0bb0cf;">$72/night</strong> with alerts watching Ketchikan suite availability.</p>
+                              <h2 class="card-title" style="margin:10px 0 12px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:22px; line-height:1.25; color:#0b1f44;">Norwegian Encore • September 1, 2024</h2>
+                              <p class="card-copy" style="margin:0 0 18px; font-family:'Helvetica Neue',Arial,sans-serif; font-size:15px; line-height:1.6; color:#0b1220;">Roundtrip Seattle with Glacier Bay scenic cruising plus free open bar and specialty dining. Watchlist tracking shows suites now <strong style="color:#0bb0cf;">$72/night</strong>.</p>
+                              <table role="presentation" cellpadding="0" cellspacing="0">
+                                <tr>
+                                  <td style="border-radius:9999px; background:rgba(20,199,232,0.1); border:1px solid rgba(20,199,232,0.35);"><a href="https://cruisora.com" style="display:inline-block; padding:10px 20px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-weight:600; font-size:14px; color:#0b1f44;">See sailing details</a></td>
+                                </tr>
+                              </table>
+                            </td>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="stack-column" style="display:block; width:100%; max-width:100%; padding-bottom:24px;">
+                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" class="card" style="background:#ffffff; border-radius:20px; border:1px solid rgba(11,31,68,0.08); overflow:hidden;">
+                          <tr>
+                            <td style="padding:28px 28px 24px;">
+                              <div style="font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:13px; letter-spacing:0.06em; text-transform:uppercase; color:#0bb0cf; font-weight:600;">South Pacific dream</div>
+                              <h2 class="card-title" style="margin:10px 0 12px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:22px; line-height:1.25; color:#0b1f44;">Oceania Regatta • October 19, 2024</h2>
+                              <p class="card-copy" style="margin:0 0 18px; font-family:'Helvetica Neue',Arial,sans-serif; font-size:15px; line-height:1.6; color:#0b1220;">Island-hop Tahiti to Fiji with specialty dining and air credit included. Limited veranda cabins now pricing <strong style="color:#0bb0cf;">$899</strong> less than brochure fares.</p>
                               <table role="presentation" cellpadding="0" cellspacing="0">
                                 <tr>
                                   <td style="border-radius:9999px; background:rgba(20,199,232,0.1); border:1px solid rgba(20,199,232,0.35);"><a href="https://cruisora.com" style="display:inline-block; padding:10px 20px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-weight:600; font-size:14px; color:#0b1f44;">See sailing details</a></td>
@@ -135,8 +157,8 @@
                   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:rgba(11,31,68,0.72); border-radius:24px;">
                     <tr>
                       <td style="padding:28px 32px; text-align:left;">
-                        <h3 style="margin:0 0 12px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:20px; line-height:1.3; color:#f6fbff;">Why cruisers trust Cruisora</h3>
-                        <p style="margin:0 0 18px; font-family:'Helvetica Neue',Arial,sans-serif; font-size:15px; line-height:1.6; color:rgba(255,255,255,0.86);">Compare price-per-night across cabins, stack line promos with agency offers, and lock in alerts when your dream itinerary drops. Download the beta app to sync your watchlist everywhere.</p>
+                        <h3 style="margin:0 0 12px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-size:20px; line-height:1.3; color:#f6fbff;">Track every price ripple</h3>
+                        <p style="margin:0 0 18px; font-family:'Helvetica Neue',Arial,sans-serif; font-size:15px; line-height:1.6; color:rgba(255,255,255,0.86);">Set fare guardrails, monitor perks, and get instant alerts from the Cruisora app when your dream itinerary shifts. Your personal cruise analyst in your pocket.</p>
                         <table role="presentation" cellpadding="0" cellspacing="0">
                           <tr>
                             <td style="border-radius:9999px; background:linear-gradient(135deg,#14c7e8,#0bb0cf);"><a href="https://cruisora.com" style="display:inline-block; padding:12px 24px; font-family:'DM Sans','Helvetica Neue',Arial,sans-serif; font-weight:600; font-size:15px; color:#f8feff;">Get the Cruisora app</a></td>
@@ -152,7 +174,7 @@
                   <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
                     <tr>
                       <td style="padding:24px 0; text-align:center; font-family:'Helvetica Neue',Arial,sans-serif; font-size:13px; line-height:1.7; color:rgba(255,255,255,0.68);" class="footer-copy">
-                        You are receiving this email because you subscribed to cruise deal alerts from Cruisora.<br />
+                        You are receiving this email because you subscribed to cruise news alerts from Cruisora.<br />
                         1200 Ocean Drive, Suite 400 · Miami Beach, FL 33139<br />
                         <a href="https://cruisora.com/preferences" style="color:#8ee8f7;">Manage preferences</a> · <a href="https://cruisora.com/unsubscribe" style="color:#8ee8f7;">Unsubscribe</a>
                       </td>


### PR DESCRIPTION
## Summary
- create a reusable Cruisora-branded HTML email template for weekly cruise deals
- mirror hero, typography, and gradient accents from the main landing page within email-safe markup
- include featured itineraries, CTAs, and footer links inspired by the existing terms and privacy pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e344d1edf4832d86571b33f8dd51bb