### PR TITLE
Add social media icons to homepage footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,34 @@
     .btn-primary:hover{ filter: brightness(.97) }
     .btn-primary:active{ transform: translateY(1px) }
 
+    /* Social icons */
+    .social-link{
+      width: 2.35rem;
+      height: 2.35rem;
+      border-radius: 9999px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: linear-gradient(140deg, rgba(20,199,232,.22), rgba(11,31,68,.9));
+      color: #f5fbff;
+      border: 1px solid rgba(255,255,255,.08);
+      box-shadow: 0 12px 28px rgba(11,31,68,.18);
+      transition: transform .2s ease, box-shadow .2s ease, opacity .2s ease;
+    }
+    .social-link svg{
+      width: 1.15rem;
+      height: 1.15rem;
+    }
+    .social-link:hover{
+      transform: translateY(-2px);
+      box-shadow: 0 16px 32px rgba(11,31,68,.24);
+      opacity: .9;
+    }
+    .social-link:focus-visible{
+      outline: 2px solid rgba(20,199,232,.58);
+      outline-offset: 3px;
+    }
+
     /* Mailchimp form tidy + compact spacing */
     #mc_embed_signup{
       background: transparent;
@@ -768,7 +796,7 @@
 
   <!-- Footer -->
   <footer class="border-t border-slate-200 bg-white">
-    <div class="mx-auto max-w-6xl px-4 py-10 text-sm text-slate-600 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div class="mx-auto max-w-6xl px-4 py-10 text-sm text-slate-600 flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
       <div class="space-y-2 sm:space-y-1">
         <p>© <span id="y"></span> cruisora • <a class="hover:underline" href="privacy.html">Privacy</a> • <a class="hover:underline" href="terms.html">Terms</a> • <a class="hover:underline" href="faq.html">FAQs</a></p>
         <p class="text-slate-500">Cruisora • <a class="hover:underline" href="tel:13056976080">305.697.6080</a> • <a class="hover:underline" href="mailto:hello@cruisora.com">hello@cruisora.com</a></p>
@@ -780,11 +808,35 @@
           <a class="hover:underline" href="#">Affiliate Disclosure</a>
         </nav>
       </div>
-      <div class="flex gap-4">
-        <a class="hover:underline" href="https://www.instagram.com/cruisora" aria-label="Instagram">Instagram</a>
-        <a class="hover:underline" href="https://www.tiktok.com/@cruisora" aria-label="TikTok">TikTok</a>
-        <a class="hover:underline" href="https://www.x.com/cruisoraapp" aria-label="X">X</a>
-        <a class="hover:underline" href="#" aria-label="LinkedIn">LinkedIn</a>
+      <div class="flex items-center gap-3 self-end sm:self-auto">
+        <a class="social-link" href="https://www.instagram.com/cruisora" aria-label="Instagram">
+          <span class="sr-only">Instagram</span>
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+            <rect x="3.6" y="3.6" width="16.8" height="16.8" rx="4.4" stroke="currentColor" stroke-width="1.5" />
+            <circle cx="12" cy="12" r="3.35" stroke="currentColor" stroke-width="1.5" />
+            <circle cx="17.3" cy="6.7" r="1.1" fill="currentColor" />
+          </svg>
+        </a>
+        <a class="social-link" href="https://www.tiktok.com/@cruisora" aria-label="TikTok">
+          <span class="sr-only">TikTok</span>
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+            <path d="M14.5 4.5c.63.84 1.5 1.5 2.54 1.83.4.12.81.19 1.2.2v3.16a6.94 6.94 0 0 1-3.53-1.08v6.02c0 3-2.32 5.45-5.3 5.45S4.1 17.63 4.1 14.66c0-3.03 2.33-5.48 5.31-5.48.37 0 .73.04 1.08.12v2.74a2.55 2.55 0 0 0-1.08-.25 2.54 2.54 0 0 0-2.54 2.54 2.54 2.54 0 0 0 2.54 2.54 2.55 2.55 0 0 0 2.55-2.55V3h3.42v1.5z" fill="currentColor" />
+          </svg>
+        </a>
+        <a class="social-link" href="https://www.x.com/cruisoraapp" aria-label="X">
+          <span class="sr-only">X</span>
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+            <path d="M5 5.25h3.02l4.18 5.76 4.67-5.76H22l-6.73 7.88L22.5 19h-3.06l-4.46-6.06L9.78 19H2l7.2-8.43L5 5.25z" fill="currentColor" />
+          </svg>
+        </a>
+        <a class="social-link" href="#" aria-label="LinkedIn">
+          <span class="sr-only">LinkedIn</span>
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+            <rect x="3.5" y="4" width="17" height="16" rx="2.6" stroke="currentColor" stroke-width="1.4" />
+            <circle cx="7.7" cy="8.3" r="1.4" fill="currentColor" />
+            <path d="M7 18.1v-6.4h2.6v6.4H7zm5.1 0v-6.4h2.5l.1 1.1c.58-.86 1.48-1.3 2.59-1.3 1.95 0 3.35 1.3 3.35 3.79v2.8H18V15c0-1.13-.54-1.79-1.5-1.79-.98 0-1.66.7-1.66 1.85v3.05H12.1z" fill="currentColor" />
+          </svg>
+        </a>
       </div>
     </div>
     <div class="mx-auto max-w-6xl px-4 pb-8 text-[11px] text-slate-400 leading-relaxed">


### PR DESCRIPTION
## Summary
- add gradient-styled social icon button treatment consistent with the Cruisora palette
- swap footer text links for SVG icons for Instagram, TikTok, X, and LinkedIn and align them to the bottom-right corner

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e345d005c8832d9b374d32cad5e9d8