### PR TITLE
Reduce hero section vertical spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,8 +535,8 @@
   </header>
 
   <!-- Hero -->
-  <section class="relative overflow-hidden hero-bg pt-16 sm:pt-20">
-    <div class="mx-auto max-w-6xl px-4 py-8 lg:py-12 grid gap-10 lg:grid-cols-2 items-center">
+  <section class="relative overflow-hidden hero-bg pt-10 sm:pt-12">
+    <div class="mx-auto max-w-6xl px-4 py-6 lg:py-8 grid gap-10 lg:grid-cols-2 items-center">
       <div class="hero-copy text-white">
         <span class="chip inline-block rounded-full px-3 py-1 text-xs uppercase tracking-wider border-white/30">Cruise deal newsletter now open</span>
         <h1 class="mt-4 text-4xl/tight lg:text-6xl heading">Find the perfect cruise. <span class="text-accent-soft">Easily.</span></h1>

--- a/index.html
+++ b/index.html
@@ -199,14 +199,14 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: 2rem 0 6rem;
+      padding: 1.5rem 0 4rem;
       perspective: 1400px;
     }
     .hero-collage{
       position: relative;
       width: min(100%, 560px);
       padding-top: 1.5rem;
-      padding-bottom: 4.5rem;
+      padding-bottom: 3rem;
       margin: 0 auto;
     }
     .hero-collage::before{
@@ -486,7 +486,7 @@
     }
     @media (max-width: 1023px){
       .hero-media{
-        padding: 2.5rem 0 3rem;
+        padding: 2rem 0 2.5rem;
       }
     }
     @media (max-width: 639px){
@@ -535,8 +535,8 @@
   </header>
 
   <!-- Hero -->
-  <section class="relative overflow-hidden hero-bg pt-28 sm:pt-32">
-    <div class="mx-auto max-w-6xl px-4 py-12 lg:py-18 grid gap-10 lg:grid-cols-2 items-center">
+  <section class="relative overflow-hidden hero-bg pt-16 sm:pt-20">
+    <div class="mx-auto max-w-6xl px-4 py-8 lg:py-12 grid gap-10 lg:grid-cols-2 items-center">
       <div class="hero-copy text-white">
         <span class="chip inline-block rounded-full px-3 py-1 text-xs uppercase tracking-wider border-white/30">Cruise deal newsletter now open</span>
         <h1 class="mt-4 text-4xl/tight lg:text-6xl heading">Find the perfect cruise. <span class="text-accent-soft">Easily.</span></h1>


### PR DESCRIPTION
## Summary
- reduce the hero section's top padding and inner container spacing to remove excess blank space
- tighten hero media padding so the collage content sits closer within the hero area

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e346fe4b4c832d8478aa652b795609