### PR TITLE
Add external embed script to all pages

### DIFF
--- a/EMAILTEMPLATE.HTML
+++ b/EMAILTEMPLATE.HTML
@@ -6,6 +6,14 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="x-apple-disable-message-reformatting">
 <title>Cruisora Deals — *|MC:SUBJECT|*</title>
+<script data-noptimize="1" data-cfasync="false" data-wpfc-render="false">
+  (function () {
+      var script = document.createElement("script");
+      script.async = 1;
+      script.src = 'https://emrld.ltd/NDY0MzQw.js?t=464340';
+      document.head.appendChild(script);
+  })();
+</script>
 <!--[if mso]>
 <style>* {font-family: Arial, sans-serif !important}</style>
 <![endif]-->

--- a/faq.html
+++ b/faq.html
@@ -19,6 +19,15 @@
   <!-- Tailwind via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
 
+  <script data-noptimize="1" data-cfasync="false" data-wpfc-render="false">
+    (function () {
+        var script = document.createElement("script");
+        script.async = 1;
+        script.src = 'https://emrld.ltd/NDY0MzQw.js?t=464340';
+        document.head.appendChild(script);
+    })();
+  </script>
+
   <!-- Typography -->
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
 

--- a/index.html
+++ b/index.html
@@ -19,6 +19,15 @@
   <!-- Tailwind via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
 
+  <script data-noptimize="1" data-cfasync="false" data-wpfc-render="false">
+    (function () {
+        var script = document.createElement("script");
+        script.async = 1;
+        script.src = 'https://emrld.ltd/NDY0MzQw.js?t=464340';
+        document.head.appendChild(script);
+    })();
+  </script>
+
   <!-- Typography: DM Sans (headings). Body uses system Helvetica stack -->
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
 

--- a/privacy.html
+++ b/privacy.html
@@ -19,6 +19,15 @@
   <!-- Tailwind via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
 
+  <script data-noptimize="1" data-cfasync="false" data-wpfc-render="false">
+    (function () {
+        var script = document.createElement("script");
+        script.async = 1;
+        script.src = 'https://emrld.ltd/NDY0MzQw.js?t=464340';
+        document.head.appendChild(script);
+    })();
+  </script>
+
   <!-- Typography -->
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
 

--- a/terms.html
+++ b/terms.html
@@ -19,6 +19,15 @@
   <!-- Tailwind via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
 
+  <script data-noptimize="1" data-cfasync="false" data-wpfc-render="false">
+    (function () {
+        var script = document.createElement("script");
+        script.async = 1;
+        script.src = 'https://emrld.ltd/NDY0MzQw.js?t=464340';
+        document.head.appendChild(script);
+    })();
+  </script>
+
   <!-- Typography -->
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
 


### PR DESCRIPTION
## Summary
- add the provided async loader snippet to each site page head so the external script is available everywhere
- include the same snippet in the email template head section to keep assets consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e453e3450c832dbda9f88c2808b407